### PR TITLE
CI : Add GitHub Workflows

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -1,0 +1,29 @@
+name: 'Bootstrap'
+description: 'Bootstrap the repository'
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.11'
+  enable-uv-cache:
+    description: 'Enable uv cache'
+    required: false
+    default: 'true'
+  cache-dependency-glob:
+    description: 'Glob pattern for cache dependencies'
+    required: false
+    default: 'uv.lock'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: ${{ inputs.enable-uv-cache }}
+        cache-dependency-glob: ${{ inputs.cache-dependency-glob }}

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project: off
+    patch: off
+
+comment:
+  layout: "diff, flags, files"
+
+fixes:
+  - "/var/snap/amazon-ssm-agent/[0-9]+/::"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,69 @@
+name: Benchmark
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:  # Manual trigger from Actions tab
+
+permissions:
+  contents: read
+  pull-requests: write  # Required to comment on PRs
+
+jobs:
+  benchmark:
+    # Run if: labeled with 'benchmark' OR manual trigger
+    if: |
+      (github.event_name == 'pull_request' && contains(github.event.label.name, 'benchmark')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+
+      - name: Run benchmarks
+        run: uv run --group dev poe benchmark
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: mujoco-usd-converter-benchmarks-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
+          path: benchmarks/*.*
+
+      - name: Comment PR with results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Wait a bit for artifacts to be fully uploaded
+            await new Promise(resolve => setTimeout(resolve, 5000));
+
+            // Get artifacts from this workflow run
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+
+            // Find the benchmark-results artifact (with PR number)
+            const artifactName = `benchmark-results-pr-${context.issue.number}`;
+            const benchmarkArtifact = artifacts.data.artifacts.find(a => a.name === artifactName);
+
+            let comment = `## Benchmark Results\n\n`;
+
+            if (benchmarkArtifact) {
+              const artifactUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/artifacts/${benchmarkArtifact.id}`;
+              comment += `[Download benchmark results](${artifactUrl})\n\n`;
+            } else {
+              const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              comment += `[View workflow run](${runUrl})\n\n`;
+            }
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,152 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:  # Manual trigger from Actions tab
+
+permissions:
+  contents: read
+  pull-requests: write  # Required to comment on PRs
+
+jobs:
+  check-code-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+
+      - name: Check uv lock file
+        run: uv lock --check
+
+      - name: Run linting
+        run: uv run --group dev poe lint
+
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+
+      - name: Update README
+        run: uv run --group dev poe update-readme
+
+      - name: Build package
+        run: uv build
+
+      - name: Restore README
+        run: git restore README.md
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mujoco-usd-converter-dist-${{ matrix.os }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
+          path: dist/
+
+  test:
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mujoco-usd-converter-dist-${{ matrix.os }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
+          path: dist/
+
+      - name: Run tests
+        run: uv run --group dev poe test-ci
+
+      - name: Upload report artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mujoco-usd-converter-coverage-${{ matrix.os }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
+          include-hidden-files: true
+          path: |
+            ${{ github.workspace }}/.coverage.xml
+            ${{ github.workspace }}/.results.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: ${{ github.workspace }}/.results.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ github.workspace }}/.coverage.xml
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-package:
+    needs: build
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bootstrap
+        uses: ./.github/actions/bootstrap
+        with:
+          enable-uv-cache: 'false'
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: mujoco-usd-converter-dist-${{ matrix.os }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || format('{0}', github.ref_name) }}
+          path: dist/
+
+      - name: Test wheel installation (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # Create a fresh virtual environment to test the wheel
+          uv venv /tmp/wheel_test_env
+          source /tmp/wheel_test_env/bin/activate
+
+          # Install the wheel directly using uv
+          uv pip install --index-strategy unsafe-best-match dist/*.whl
+
+          # Test conversion
+          mkdir -p /tmp/test_outputs
+          mujoco_usd_converter tests/data/geoms.xml /tmp/test_outputs/geoms_output
+
+      - name: Test wheel installation (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          # Create a fresh virtual environment to test the wheel
+          uv venv wheel_test_env
+          wheel_test_env\Scripts\activate.ps1
+
+          # Find and install the wheel file
+          $wheelFile = Get-ChildItem -Path "dist" -Filter "*.whl" | Select-Object -First 1
+          uv pip install --index-strategy unsafe-best-match $wheelFile.FullName
+
+          # Test conversion
+          New-Item -ItemType Directory -Force -Path test_outputs
+          mujoco_usd_converter tests/data/geoms.xml test_outputs\geoms_output


### PR DESCRIPTION
## Description

This adds GitHub Workflows equivalent to the internal Gitlab CI for
- linting/fotmatting
- building (ubuntu & windows)
- testing (ubuntu & windows)
  - The full test suite runs from a dev venv & produces coverage & test reports
  - Coverage report & test results _should_ upload to Codecov [here](https://app.codecov.io/gh/newton-physics), but this hasn't been verified yet (it needs the token for the org)
  - A minimal single test runs from the packaged wheel without dev dependencies
- optional benchmark reporting
  - This is triggered manually on PRs by appling the `benchmark` label or on branches via Workflow Dispatch events.

I simulated testing this on my fork as the changes needed to be on `main` before they could run.
- Simulated PR results [here](https://github.com/andrewkaufman/mujoco-usd-converter/pull/1)
- Simulated `main` results [here](https://github.com/andrewkaufman/mujoco-usd-converter/actions)

I have intentionally not ported the deploy job from Gitlab as deployments will still be handled internally at NVIDIA for now.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
