### PR TITLE
Body : Remove ArticulationRootAPI from non-jointed bodies

### DIFF
--- a/tests/data/bodies.xml
+++ b/tests/data/bodies.xml
@@ -4,6 +4,7 @@
             <geom type="box" size="0.1 0.1 0.1"/>
             <body name="nested_body" pos="0 1 0">
                 <geom type="box" size="0.1 0.1 0.1"/>
+                <joint type="hinge"/>
             </body>
         </body>
 

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -18,7 +18,7 @@ class TestBodies(ConverterTestCase):
         self.stage: Usd.Stage = Usd.Stage.Open(asset.path)
         self.assertIsValidUsd(self.stage)
 
-    def test_bodies(self):
+    def test_articulation_roots(self):
         # Root body is an Articulation Root
         prim = self.stage.GetPrimAtPath("/bodies/Geometry/root_body")
         self.assertTrue(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
@@ -26,6 +26,11 @@ class TestBodies(ConverterTestCase):
 
         # Nested Body is not an articulation root
         prim = self.stage.GetPrimAtPath("/bodies/Geometry/root_body/nested_body")
+        self.assertFalse(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+
+        # Kinematic Body is not an articulation root as there are no joints to its child bodies
+        prim = self.stage.GetPrimAtPath("/bodies/Geometry/kinematic_body")
         self.assertFalse(prim.HasAPI(UsdPhysics.ArticulationRootAPI))
         self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
 


### PR DESCRIPTION
## Description

If the body is a direct child of the worldbody, and is connected by a joint to another body, then the `UsdPhysics.ArticulationRootAPI` should be applied, to indicate that this Prim is the root of an articulation.

However, the current code was applying the `UsdPhysics.ArticulationRootAPI` to any child of the worldbody.

Fixes #3

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
