### PR TITLE
Lock to mujoco 3.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mujoco>=3.3.5",
+    "mujoco==3.3.5",
     "usd-exchange>=2.1.0a3", # locked to USD 25.05
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",

--- a/uv.lock
+++ b/uv.lock
@@ -270,7 +270,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mujoco", specifier = ">=3.3.5" },
+    { name = "mujoco", specifier = "==3.3.5" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
     { name = "usd-exchange", specifier = ">=2.1.0a3" },


### PR DESCRIPTION
mujoco 3.3.6 introduced a breaking change to the compiler flags which is not reflected in the USD schema. we need to wait for a schema fix before moving up

Note also the schema itself is locked to 3.3.5 in install_mjc_schema so we really should match that here. Ideally that script could disappear if mujoco ships the schema in their own package at some point...

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
