### PR TITLE
Unit tests: Changed the check for external references to use HasAuthoredReferences

### DIFF
--- a/tests/testAssetStructure.py
+++ b/tests/testAssetStructure.py
@@ -167,7 +167,7 @@ class TestAssetStructure(ConverterTestCase):
         # Test that all descendant prims which are meshes are references
         for prim in geometry_stage.TraverseAll():
             if prim.IsA(UsdGeom.Mesh):
-                self.assertTrue(prim.GetReferences(), f"Mesh {prim.GetPath()} should be a reference")
+                self.assertTrue(prim.HasAuthoredReferences(), f"Mesh {prim.GetPath()} should be a reference")
                 prim_specs: list[Sdf.PrimSpec] = prim.GetPrimStack()
                 self.assertEqual(len(prim_specs), 2)
                 self.assertEqual(prim_specs[0].layer.identifier, (parent_path / pathlib.Path("./Payload/Geometry.usda")).as_posix())

--- a/tests/testMaterial.py
+++ b/tests/testMaterial.py
@@ -76,7 +76,7 @@ class TestMaterial(ConverterTestCase):
         self.assertEqual(material.GetPrim().GetName(), "Grid")
         self.assertEqual(material.GetPrim().GetParent(), self.stage.GetPrimAtPath(f"/{self.model_name}/Materials"))
         # materials are references to the material library layer
-        self.assertTrue(material.GetPrim().GetReferences())
+        self.assertTrue(material.GetPrim().HasAuthoredReferences())
 
     def test_unnamed_texture_material(self):
         shader = self._get_shader("UnnamedTexture")

--- a/tests/testMesh.py
+++ b/tests/testMesh.py
@@ -22,7 +22,7 @@ class TestMesh(ConverterTestCase):
         stl_mesh_prim: Usd.Prim = stage.GetPrimAtPath(f"/{model_name}/Geometry/body1/StlBox")
         self.assertTrue(stl_mesh_prim)
         # meshes are references to the geometry library layer
-        self.assertTrue(stl_mesh_prim.GetReferences())
+        self.assertTrue(stl_mesh_prim.HasAuthoredReferences())
         usd_mesh_stl = UsdGeom.Mesh(stl_mesh_prim)
         self.assertTrue(usd_mesh_stl.GetPointsAttr().HasAuthoredValue())
         self.assertTrue(usd_mesh_stl.GetFaceVertexCountsAttr().HasAuthoredValue())
@@ -38,7 +38,7 @@ class TestMesh(ConverterTestCase):
         obj_mesh_prim: Usd.Prim = stage.GetPrimAtPath(f"/{model_name}/Geometry/body1/body2/ObjBox")
         self.assertTrue(obj_mesh_prim)
         # meshes are references to the geometry library layer
-        self.assertTrue(obj_mesh_prim.GetReferences())
+        self.assertTrue(obj_mesh_prim.HasAuthoredReferences())
         usd_mesh_obj = UsdGeom.Mesh(obj_mesh_prim)
         self.assertTrue(usd_mesh_obj.GetPointsAttr().HasAuthoredValue())
         self.assertTrue(usd_mesh_obj.GetFaceVertexCountsAttr().HasAuthoredValue())
@@ -57,7 +57,7 @@ class TestMesh(ConverterTestCase):
         mesh_prim: Usd.Prim = stage.GetPrimAtPath(f"/{model_name}/Geometry/body1/body2/box")
         self.assertTrue(mesh_prim)
         # meshes are references to the geometry library layer
-        self.assertTrue(mesh_prim.GetReferences())
+        self.assertTrue(mesh_prim.HasAuthoredReferences())
         usd_mesh = UsdGeom.Mesh(mesh_prim)
         self.assertTrue(usd_mesh.GetPointsAttr().HasAuthoredValue())
         self.assertTrue(usd_mesh.GetFaceVertexCountsAttr().HasAuthoredValue())


### PR DESCRIPTION
## Description

There was a place in the unit tests where an external reference was checked using ```self.assertTrue(obj_mesh_prim.GetReference())```.  
However, this will result in True regardless of which prim it is used with.   

I made the following changes to determine whether an external reference has a specified path.  

```py
self.assertTrue(prim.HasAuthoredReferences())
```

UsdPrim::HasAuthoredReferences : https://openusd.org/release/api/class_usd_prim.html#aa0fccfa8055d7725bd0c1be63c02bbe4

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
