### PR TITLE
Add material interfaces, make materials instanceable, fix emission

### DIFF
--- a/mujoco_usd_converter/_impl/material.py
+++ b/mujoco_usd_converter/_impl/material.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
 import shutil
@@ -82,6 +82,13 @@ def convert_material(parent: Usd.Prim, name: str, material: mujoco.MjsMaterial, 
 
     if not material_prim:
         Tf.RaiseRuntimeError(f'Failed to convert material "{name}"')
+
+    result = usdex.core.addPreviewMaterialInterface(material_prim)
+    if not result:
+        Tf.RaiseRuntimeError(f'Failed to add material instance to material prim "{material_prim.GetPath()}"')
+
+    material_prim.GetPrim().SetInstanceable(True)
+
     return material_prim
 
 

--- a/tests/testAssetStructure.py
+++ b/tests/testAssetStructure.py
@@ -380,6 +380,10 @@ class TestAssetStructure(ConverterTestCase):
 
         texture_input: UsdShade.Input = shader.GetInput("diffuseColor")
         connected_source = texture_input.GetConnectedSource()
-        texture_prim = connected_source[0].GetPrim()
-        texture_file_attr = texture_prim.GetAttribute("inputs:file")
+        texture_shader_prim = UsdShade.Shader(connected_source[0].GetPrim())
+
+        # The values are defined in the material interface, not in the shader
+        value_attrs = UsdShade.Utils.GetValueProducingAttributes(texture_shader_prim.GetInput("file"))
+        self.assertEqual(value_attrs[0].GetPrim(), material_prim)
+        texture_file_attr = value_attrs[0]
         self.assertEqual(texture_file_attr.Get().path, "./Textures/grid.png")


### PR DESCRIPTION
## Description
<!-- Set a descriptive pull request title. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues relevant to this PR. -->
Fixes issue #44 

- Fix emission by setting the preview shader's `emissiveColor` to `rgba * emission`
  - From the mapping document: `UPS - "Emission" should be manually multiplied by "rgb" and the result mapped to "emissiveColor"`
- Add material interfaces and test
  - This also required changes to the layer flattening code
- Make materials instanceable/instances and test

Before emission fix:
<img height="480" alt="Before emission fixed" src="https://github.com/user-attachments/assets/ae038603-54d1-4221-b3d2-7853e97c90ea" />

After emission fix:
<img height="480" alt="After emission fixed" src="https://github.com/user-attachments/assets/088b9f08-5f48-4536-a339-672da4c44a53" />

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
