### PR TITLE
Add unit test with fitaabb=true

### DIFF
--- a/tests/data/geoms_fitting.xml
+++ b/tests/data/geoms_fitting.xml
@@ -9,7 +9,9 @@
   </default>
 
   <asset>
-      <mesh name="complex_cube" file="assets/complex_cube.obj"/>
+      <!-- When fitting a mesh, an error occurs if the capsule's XYZ bounding box coordinates are uniform. -->
+      <!-- To avoid this, we apply scaling to deliberately transform it into an uneven bounding box. -->
+      <mesh name="complex_cube" file="assets/complex_cube.obj" scale="1.3 1.0 1.0"/>
       <mesh name="rectangle_x" file="assets/box.obj" scale="1.2 0.3 0.2"/>
       <mesh name="rectangle_y" file="assets/box.obj" scale="0.3 1.2 0.2"/>
       <mesh name="rectangle_z" file="assets/box.obj" scale="0.3 0.2 1.2"/>

--- a/tests/data/geoms_fitting_aabb.xml
+++ b/tests/data/geoms_fitting_aabb.xml
@@ -9,7 +9,9 @@
   </default>
 
   <asset>
-      <mesh name="complex_cube" file="assets/complex_cube.obj"/>
+      <!-- When fitting a mesh, an error occurs if the capsule's XYZ bounding box coordinates are uniform. -->
+      <!-- To avoid this, we apply scaling to deliberately transform it into an uneven bounding box. -->
+      <mesh name="complex_cube" file="assets/complex_cube.obj" scale="1.3 1.0 1.0"/>
       <mesh name="rectangle_x" file="assets/box.obj" scale="1.2 0.3 0.2"/>
       <mesh name="rectangle_y" file="assets/box.obj" scale="0.3 1.2 0.2"/>
       <mesh name="rectangle_z" file="assets/box.obj" scale="0.3 0.2 1.2"/>
@@ -41,13 +43,10 @@
       <geom name="cylinder_visual" class="visual" type="mesh" mesh="complex_cube"/>
       <geom name="cylinder" type="cylinder" mesh="complex_cube" rgba="1 0 1 0.3"/>
     </body>
-    <!-- TODO: Capsule fitting will result in an error in MuJoCo 3.5.0. -->
-    <!--
     <body name="fitting_capsule_no_transform" childclass="base" pos="6 0 0">
       <geom name="capsule_visual" class="visual" type="mesh" mesh="complex_cube"/>
       <geom name="capsule" type="capsule" mesh="complex_cube" rgba="1 0 1 0.3"/>
     </body>
-    -->
 
     <!-- Unsupported geometric primitive. -->
     <body name="fitting_ellipsoid_no_transform" childclass="base" pos="8 0 0">
@@ -68,13 +67,10 @@
       <geom name="cylinder_visual_with_transform" class="visual" type="mesh" mesh="complex_cube" pos="0.1 0.0 -0.5" quat="0.6964 0.6964 -0.1228 -0.1228"/>
       <geom name="cylinder_with_transform" type="cylinder" mesh="complex_cube" pos="0.1 0.0 -0.5" quat="0.6964 0.6964 -0.1228 -0.1228" rgba="1 0 1 0.3"/>
     </body>
-    <!-- TODO: Capsule fitting will result in an error in MuJoCo 3.5.0. -->
-    <!--
     <body name="fitting_capsule_with_transform" childclass="base" pos="6 0 2">
       <geom name="capsule_visual_with_transform" class="visual" type="mesh" mesh="complex_cube" pos="0.1 0.0 -0.5" quat="0.6964 0.6964 -0.1228 -0.1228"/>
       <geom name="capsule_with_transform" type="capsule" mesh="complex_cube" pos="0.1 0.0 -0.5" quat="0.6964 0.6964 -0.1228 -0.1228" rgba="1 0 1 0.3"/>
     </body>
-    -->
 
     <!-- Fitting with geometric primitives. Specify the fitscale. -->
     <body name="fitting_box_with_fitscale" childclass="base" pos="0 0 4">
@@ -89,13 +85,10 @@
       <geom name="cylinder_visual_with_fitscale" class="visual" type="mesh" mesh="complex_cube" quat="0.6964 0.6964 -0.1228 -0.1228"/>
       <geom name="cylinder_with_fitscale" type="cylinder" mesh="complex_cube" quat="0.6964 0.6964 -0.1228 -0.1228" fitscale="1.2" rgba="1 0 1 0.3"/>
     </body>
-    <!-- TODO: Capsule fitting will result in an error in MuJoCo 3.5.0. -->
-    <!--
     <body name="fitting_capsule_with_fitscale" childclass="base" pos="6 0 4">
       <geom name="capsule_visual_with_fitscale" class="visual" type="mesh" mesh="complex_cube" quat="0.6964 0.6964 -0.1228 -0.1228"/>
       <geom name="capsule_with_fitscale" type="capsule" mesh="complex_cube" quat="0.6964 0.6964 -0.1228 -0.1228" fitscale="1.2" rgba="1 0 1 0.3"/>
     </body>
-    -->
 
     <!-- A box scaled non-uniformly in XYZ. -->
     <body name="fitting_box_scaled_x" childclass="base" pos="0 0 6">
@@ -137,8 +130,6 @@
       <geom name="cylinder_scaled_z" type="cylinder" mesh="rectangle_z" rgba="1 0 1 0.3"/>
     </body>
 
-    <!-- TODO: Capsule fitting will result in an error in MuJoCo 3.5.0. -->
-    <!--
     <body name="fitting_capsule_scaled_x" childclass="base" pos="6 0 6">
       <geom name="capsule_visual_scaled_x" class="visual" type="mesh" mesh="rectangle_x"/>
       <geom name="capsule_scaled_x" type="capsule" mesh="rectangle_x" rgba="1 0 1 0.3"/>
@@ -151,6 +142,5 @@
       <geom name="capsule_visual_scaled_z" class="visual" type="mesh" mesh="rectangle_z"/>
       <geom name="capsule_scaled_z" type="capsule" mesh="rectangle_z" rgba="1 0 1 0.3"/>
     </body>
-    -->
   </worldbody>
 </mujoco>

--- a/tests/testGeomFitting.py
+++ b/tests/testGeomFitting.py
@@ -86,9 +86,9 @@ class TestGeomFitting(ConverterTestCase):
         self.assertEqual(cube.GetSizeAttr().Get(), 2)
 
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
-        self.assertTrue(Gf.IsClose(scale, (0.47636932, 0.49139905, 0.5194262), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03074589395921, 0.501516571216, -0.02411530172992), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(scale, (0.48377457, 0.49567172, 0.6591854), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.03996189659229483, 0.5015098822207877, -0.02410985048867517), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_box_with_transform/box_with_transform"
@@ -99,9 +99,9 @@ class TestGeomFitting(ConverterTestCase):
         cube = UsdGeom.Cube(prim)
         self.assertEqual(cube.GetSizeAttr().Get(), 2)
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
-        self.assertTrue(Gf.IsClose(scale, (0.47636932, 0.49139905, 0.5194262), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.13713980789211, 0.012144646664811, 0.001516571216727), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(scale, (0.48377457, 0.49567172, 0.6591854), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.14579810132345178, 0.008987323573032321, 0.0015098822207878504), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_box_with_fitscale/box_with_fitscale"
@@ -112,9 +112,9 @@ class TestGeomFitting(ConverterTestCase):
         cube = UsdGeom.Cube(prim)
         self.assertEqual(cube.GetSizeAttr().Get(), 2)
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
-        self.assertTrue(Gf.IsClose(scale, (0.5716432, 0.5896788, 0.62331146), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03713980789211, 0.012144646664811, 0.5015165712167), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(scale, (0.58052945, 0.5948061, 0.79102254), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.045798101323451766, 0.008987323573032321, 0.5015098822207879), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_box_scaled_x/box_scaled_x"
@@ -165,11 +165,11 @@ class TestGeomFitting(ConverterTestCase):
         self.assertTrue(prim.IsA(UsdGeom.Sphere))
 
         sphere = UsdGeom.Sphere(prim)
-        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.4957315243758671, 1e-6))
+        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.5462105768323134, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03074589395921, 0.501516571216, -0.02411530172992), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(translation, (0.03996189659229483, 0.5015098822207877, -0.02410985048867517), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_sphere_with_transform/sphere_with_transform"
@@ -178,11 +178,11 @@ class TestGeomFitting(ConverterTestCase):
         self.assertTrue(prim.IsA(UsdGeom.Sphere))
 
         sphere = UsdGeom.Sphere(prim)
-        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.4957315243758671, 1e-6))
+        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.5462105768323134, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.13713980789211, 0.012144646664811, 0.001516571216727), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.14579810132345178, 0.008987323573032321, 0.0015098822207878504), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_sphere_with_fitscale/sphere_with_fitscale"
@@ -191,11 +191,11 @@ class TestGeomFitting(ConverterTestCase):
         self.assertTrue(prim.IsA(UsdGeom.Sphere))
 
         sphere = UsdGeom.Sphere(prim)
-        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.5948778292510405, 1e-6))
+        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.6554526921987761, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03713980789211, 0.012144646664811, 0.5015165712167), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.045798101323451766, 0.008987323573032321, 0.5015098822207879), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_sphere_scaled_x/sphere_scaled_x"
@@ -247,12 +247,12 @@ class TestGeomFitting(ConverterTestCase):
 
         cylinder = UsdGeom.Cylinder(prim)
         self.assertEqual(cylinder.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.4838841777760525, 1e-6))
-        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.0388524351509925, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.4897231473880021, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.318370871441872, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03074589395921, 0.501516571216, -0.02411530172992), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(translation, (0.03996189659229483, 0.5015098822207877, -0.02410985048867517), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_cylinder_with_transform/cylinder_with_transform"
@@ -262,12 +262,12 @@ class TestGeomFitting(ConverterTestCase):
 
         cylinder = UsdGeom.Cylinder(prim)
         self.assertEqual(cylinder.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.4838841777760525, 1e-6))
-        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.0388524351509925, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.4897231473880021, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.318370871441872, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.1371398078921, 0.01214464666481, 0.00151657121672), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.14579810132345178, 0.008987323573032321, 0.0015098822207878504), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_cylinder_with_fitscale/cylinder_with_fitscale"
@@ -277,12 +277,12 @@ class TestGeomFitting(ConverterTestCase):
 
         cylinder = UsdGeom.Cylinder(prim)
         self.assertEqual(cylinder.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.580661013331263, 1e-6))
-        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.2466229221811909, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.5876677768656025, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.5820450457302464, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03713980789211787, 0.012144646664811277, 0.5015165712167277), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.045798101323451766, 0.008987323573032321, 0.5015098822207879), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_cylinder_scaled_x/cylinder_scaled_x"
@@ -340,12 +340,12 @@ class TestGeomFitting(ConverterTestCase):
 
         capsule = UsdGeom.Capsule(prim)
         self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.4838841777760525, 1e-6))
-        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.5549682573749399, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.4897231473880021, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.8286477240538699, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03074589395921, 0.501516571216, -0.02411530172992), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(translation, (0.03996189659229483, 0.5015098822207877, -0.02410985048867517), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_with_transform/capsule_with_transform"
@@ -355,12 +355,12 @@ class TestGeomFitting(ConverterTestCase):
 
         capsule = UsdGeom.Capsule(prim)
         self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.4838841777760525, 1e-6))
-        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.5549682573749399, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.4897231473880021, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.8286477240538699, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.13713980789211788, 0.012144646664811277, 0.001516571216727658), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.14579810132345178, 0.008987323573032321, 0.0015098822207878504), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_with_fitscale/capsule_with_fitscale"
@@ -370,12 +370,12 @@ class TestGeomFitting(ConverterTestCase):
 
         capsule = UsdGeom.Capsule(prim)
         self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.580661013331263, 1e-6))
-        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.6659619088499279, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.5876677768656025, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.9943772688646438, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.03713980789211787, 0.012144646664811277, 0.5015165712167277), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.045798101323451766, 0.008987323573032321, 0.5015098822207879), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_scaled_x/capsule_scaled_x"

--- a/tests/testGeomFittingAABB.py
+++ b/tests/testGeomFittingAABB.py
@@ -86,9 +86,9 @@ class TestGeomFittingAABB(ConverterTestCase):
         self.assertEqual(cube.GetSizeAttr().Get(), 2)
 
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
-        self.assertTrue(Gf.IsClose(scale, (0.8559072, 0.7781741, 0.70797443), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.005380221417930632, 0.4999997998975669, -0.004139026615141719), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(scale, (0.7532054, 0.75478935, 0.76835316), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.04823722128442205, 0.4989525530226528, -0.006278505815367666), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_box_with_transform/box_with_transform"
@@ -99,9 +99,9 @@ class TestGeomFittingAABB(ConverterTestCase):
         cube = UsdGeom.Cube(prim)
         self.assertEqual(cube.GetSizeAttr().Get(), 2)
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
-        self.assertTrue(Gf.IsClose(scale, (0.8559072, 0.7781741, 0.70797443), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.10647141846274108, 0.0020491624891415972, -2.0010243301227248e-7), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(scale, (0.7532054, 0.75478935, 0.76835316), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.14747536245281256, -0.010599014694299781, -0.0010474469773470996), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_box_with_fitscale/box_with_fitscale"
@@ -112,9 +112,9 @@ class TestGeomFittingAABB(ConverterTestCase):
         cube = UsdGeom.Cube(prim)
         self.assertEqual(cube.GetSizeAttr().Get(), 2)
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
-        self.assertTrue(Gf.IsClose(scale, (1.0270886, 0.93380886, 0.8495693), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.006471418462741075, 0.0020491624891415972, 0.499999799897567), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(scale, (0.9038465, 0.9057472, 0.9220238), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.04747536245281256, -0.010599014694299781, 0.4989525530226529), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_box_scaled_x/box_scaled_x"
@@ -165,11 +165,11 @@ class TestGeomFittingAABB(ConverterTestCase):
         self.assertTrue(prim.IsA(UsdGeom.Sphere))
 
         sphere = UsdGeom.Sphere(prim)
-        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.8559072194762076, 1e-6))
+        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.7683531441266045, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.005380221417930632, 0.4999997998975669, -0.004139026615141719), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(translation, (0.04823722128442205, 0.4989525530226528, -0.006278505815367666), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_sphere_with_transform/sphere_with_transform"
@@ -178,11 +178,11 @@ class TestGeomFittingAABB(ConverterTestCase):
         self.assertTrue(prim.IsA(UsdGeom.Sphere))
 
         sphere = UsdGeom.Sphere(prim)
-        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.8559072194762076, 1e-6))
+        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.7683531441266045, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.10647141846274108, 0.0020491624891415972, -2.0010243301227248e-7), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.14747536245281256, -0.010599014694299781, -0.0010474469773470996), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_sphere_with_fitscale/sphere_with_fitscale"
@@ -191,11 +191,11 @@ class TestGeomFittingAABB(ConverterTestCase):
         self.assertTrue(prim.IsA(UsdGeom.Sphere))
 
         sphere = UsdGeom.Sphere(prim)
-        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 1.027088663371449, 1e-6))
+        self.assertTrue(Gf.IsClose(sphere.GetRadiusAttr().Get(), 0.9220237729519254, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.006471418462741075, 0.0020491624891415972, 0.499999799897567), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.04747536245281256, -0.010599014694299781, 0.4989525530226529), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_sphere_scaled_x/sphere_scaled_x"
@@ -247,12 +247,12 @@ class TestGeomFittingAABB(ConverterTestCase):
 
         cylinder = UsdGeom.Cylinder(prim)
         self.assertEqual(cylinder.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.8559072194762076, 1e-6))
-        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.4159488607901767, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.7547893248064179, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.536706288253209, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.005380221417930632, 0.4999997998975669, -0.004139026615141719), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.11115205, 0.86828923, 0.22571543, 0.42751792))
+        self.assertTrue(Gf.IsClose(translation, (0.04823722128442205, 0.4989525530226528, -0.006278505815367666), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
 
         # When using transform(pos, quat) in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_cylinder_with_transform/cylinder_with_transform"
@@ -262,12 +262,12 @@ class TestGeomFittingAABB(ConverterTestCase):
 
         cylinder = UsdGeom.Cylinder(prim)
         self.assertEqual(cylinder.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.8559072194762076, 1e-6))
-        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.4159488607901767, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.7547893248064179, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.536706288253209, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.10647141846274108, 0.0020491624891415972, -2.0010243301227248e-7), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.14747536245281256, -0.010599014694299781, -0.0010474469773470996), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # When using transform(quat) and fitscale in geom.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_cylinder_with_fitscale/cylinder_with_fitscale"
@@ -277,12 +277,12 @@ class TestGeomFittingAABB(ConverterTestCase):
 
         cylinder = UsdGeom.Cylinder(prim)
         self.assertEqual(cylinder.GetAxisAttr().Get(), UsdGeom.Tokens.z)
-        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 1.027088663371449, 1e-6))
-        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.6991386329482119, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetRadiusAttr().Get(), 0.9057471897677014, 1e-6))
+        self.assertTrue(Gf.IsClose(cylinder.GetHeightAttr().Get(), 1.8440475459038508, 1e-6))
         translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
         self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
-        self.assertTrue(Gf.IsClose(translation, (0.006471418462741075, 0.0020491624891415972, 0.499999799897567), 1e-6))
-        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.44702968, 0.65726686, -0.26079687, 0.54785925))
+        self.assertTrue(Gf.IsClose(translation, (0.04747536245281256, -0.010599014694299781, 0.4989525530226529), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
 
         # A box scaled non-uniformly in XYZ. Long in the X direction.
         prim_path = f"{default_prim.GetPath()}/Geometry/fitting_cylinder_scaled_x/cylinder_scaled_x"
@@ -329,5 +329,95 @@ class TestGeomFittingAABB(ConverterTestCase):
         self.assertTrue(Gf.IsClose(translation, (0, 0, 0), 1e-6))
         self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.70710677, 0, 0, 0.70710677))
 
-    # TODO: When fitaabb="true", the capsule causes a compile-time error (MuJoCo 3.5.0).
-    # We have not yet included tests for the capsule case here.
+    def test_geom_fitting_capsule(self):
+        default_prim = self.stage.GetDefaultPrim()
+
+        # When not using transform(pos, quat) in geom.
+        prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_no_transform/capsule"
+        prim = self.stage.GetPrimAtPath(prim_path)
+        self.assertTrue(prim)
+        self.assertTrue(prim.IsA(UsdGeom.Capsule))
+
+        capsule = UsdGeom.Capsule(prim)
+        self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.7547893248064179, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.027127638640373153, 1e-6))
+        translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
+        self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.04823722128442205, 0.4989525530226528, -0.006278505815367666), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.31025994, 0.6706377, 0.3387701, 0.58242476))
+
+        # When using transform(pos, quat) in geom.
+        prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_with_transform/capsule_with_transform"
+        prim = self.stage.GetPrimAtPath(prim_path)
+        self.assertTrue(prim)
+        self.assertTrue(prim.IsA(UsdGeom.Capsule))
+
+        capsule = UsdGeom.Capsule(prim)
+        self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.7547893248064179, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.027127638640373153, 1e-6))
+        translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
+        self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.14747536245281256, -0.010599014694299781, -0.0010474469773470996), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
+
+        # When using transform(quat) and fitscale in geom.
+        prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_with_fitscale/capsule_with_fitscale"
+        prim = self.stage.GetPrimAtPath(prim_path)
+        self.assertTrue(prim)
+        self.assertTrue(prim.IsA(UsdGeom.Capsule))
+
+        capsule = UsdGeom.Capsule(prim)
+        self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.9057471897677014, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.03255316636844778, 1e-6))
+        translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
+        self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0.04747536245281256, -0.010599014694299781, 0.4989525530226529), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(-0.1378371, 0.65314186, -0.29012004, 0.68573827))
+
+        # A box scaled non-uniformly in XYZ. Long in the X direction.
+        prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_scaled_x/capsule_scaled_x"
+        prim = self.stage.GetPrimAtPath(prim_path)
+        self.assertTrue(prim)
+        self.assertTrue(prim.IsA(UsdGeom.Capsule))
+
+        capsule = UsdGeom.Capsule(prim)
+        self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.1500000000000006, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.9000000000000037, 1e-6))
+        translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
+        self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0, 0, 0), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0, 0.70710677, 0, 0.70710677))
+
+        # A box scaled non-uniformly in XYZ. Long in the Y direction.
+        prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_scaled_y/capsule_scaled_y"
+        prim = self.stage.GetPrimAtPath(prim_path)
+        self.assertTrue(prim)
+        self.assertTrue(prim.IsA(UsdGeom.Capsule))
+
+        capsule = UsdGeom.Capsule(prim)
+        self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.15000000000000038, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.9000000000000024, 1e-6))
+        translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
+        self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0, 0, 0), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.5, 0.5, -0.5, 0.5))
+
+        # A box scaled non-uniformly in XYZ. Long in the Z direction.
+        prim_path = f"{default_prim.GetPath()}/Geometry/fitting_capsule_scaled_z/capsule_scaled_z"
+        prim = self.stage.GetPrimAtPath(prim_path)
+        self.assertTrue(prim)
+        self.assertTrue(prim.IsA(UsdGeom.Capsule))
+
+        capsule = UsdGeom.Capsule(prim)
+        self.assertEqual(capsule.GetAxisAttr().Get(), UsdGeom.Tokens.z)
+        self.assertTrue(Gf.IsClose(capsule.GetRadiusAttr().Get(), 0.1500000000000002, 1e-6))
+        self.assertTrue(Gf.IsClose(capsule.GetHeightAttr().Get(), 0.9000000000000011, 1e-6))
+        translation, pivot, quat, scale = usdex.core.getLocalTransformComponentsQuat(prim)
+        self.assertTrue(Gf.IsClose(scale, (1, 1, 1), 1e-6))
+        self.assertTrue(Gf.IsClose(translation, (0, 0, 0), 1e-6))
+        self.assertRotationsAlmostEqual(quat, Gf.Quatf(0.70710677, 0, 0, 0.70710677))


### PR DESCRIPTION
## Description

Fixes #19 

- In `tests/data/geoms_fitting.xml`, geom names were added where they were missing. 
  - If the geom name attribute is absent, compilation will not occur, resulting in outcomes differing from MuJoCo.
- In `tests/data/geoms_fitting.xml`,  added `rgba="1 0 1 0.3"` to geom.
  - This makes it easier to visually verify the results of fitaabb in MuJoCo's viewer or usdview. 
- In `tests/data/geoms_fitting.xml`, The XYZ coordinates of the bounding box for `assets/complex_cube.obj` are nearly identical in size.  
In this case, setting fitaabb to true caused errors during MuJoCo compilation when dealing with capsules.  
To avoid this, I added a scale to make the sizes non-uniform.  
```xml
<mesh name="complex_cube" file="assets/complex_cube.obj" scale="1.3 1.0 1.0"/>
```
- Added unit tests when `fitaabb=true`.
  - MuJoCo file: `tests/data/geoms_fitting_aabb.xml`
  - Unit test: tests/testGeomFittingAABB.py

`geoms_fitting.xml` and `geoms_fitting_aabb.xml` differ only in the True/False setting for `compiler fitaabb`.  

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
