### PR TITLE
Add support for contact excludes

### DIFF
--- a/mujoco_usd_converter/_impl/convert.py
+++ b/mujoco_usd_converter/_impl/convert.py
@@ -15,6 +15,7 @@ from ._flatten import export_flattened
 from .actuator import convert_actuators
 from .body import convert_bodies
 from .data import ConversionData, Tokens
+from .exclude import convert_excludes
 from .material import convert_materials
 from .mesh import convert_meshes
 from .scene import convert_scene
@@ -131,6 +132,8 @@ class Converter:
         # author the actuators
         convert_actuators(data)
 
+        convert_excludes(data)
+
         # create the asset interface
         usdex.core.addAssetInterface(asset_stage, source=data.content[Tokens.Contents])
 
@@ -158,8 +161,6 @@ class Converter:
             Tf.Warn("skins are not supported")
         if spec.equalities:
             Tf.Warn("equalities are not supported")
-        if spec.excludes:
-            Tf.Warn("excludes are not supported")
         if spec.pairs:
             Tf.Warn("pairs are not supported")
         if spec.sensors:

--- a/mujoco_usd_converter/_impl/exclude.py
+++ b/mujoco_usd_converter/_impl/exclude.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from pxr import Tf, UsdPhysics
+
+from .data import ConversionData, Tokens
+
+__all__ = ["convert_excludes"]
+
+
+def convert_excludes(data: ConversionData):
+    if not data.spec.excludes:
+        return
+
+    for exclude in data.spec.excludes:
+        if exclude.bodyname1 not in data.references[Tokens.PhysicsBodies] or exclude.bodyname2 not in data.references[Tokens.PhysicsBodies]:
+            Tf.Warn(f"Body '{exclude.bodyname1}' or '{exclude.bodyname2}' not found for contact exclude")
+            continue
+
+        body1 = data.references[Tokens.PhysicsBodies][exclude.bodyname1].GetPrim()
+        body2 = data.references[Tokens.PhysicsBodies][exclude.bodyname2].GetPrim()
+
+        # Add the UsdPhysicsFilgeredPairsAPI to the first body
+        UsdPhysics.FilteredPairsAPI.Apply(body1)
+        filtered_pairs_api = UsdPhysics.FilteredPairsAPI(body1)
+        filtered_pairs_api.GetFilteredPairsRel().AddTarget(body2.GetPath())

--- a/tests/data/contact_excludes.xml
+++ b/tests/data/contact_excludes.xml
@@ -1,0 +1,36 @@
+<mujoco model="contact_excludes">
+  <worldbody>
+    <!-- ground plane: collides with everything -->
+    <geom name="ground" type="plane" size="5 5 0.01" rgba="0.5 0.5 0.5 1"/>
+
+    <!-- always-collider box sitting on the ground -->
+    <body name="collider" pos="0 0 0.15">
+      <freejoint/>
+      <geom type="box" size="0.15 0.15 0.15" rgba="1 0 0 1"/>
+    </body>
+
+    <!-- three boxes that will NOT collide with each other, stacked in the air so they overlap -->
+    <body name="no_collide_A" pos="-0.1 0 1.0">
+      <freejoint/>
+      <geom type="box" size="0.15 0.15 0.15" rgba="0 0.6 1 0.5"/>
+    </body>
+
+    <body name="no_collide_B" pos="0 0 1.0">
+      <freejoint/>
+      <geom type="box" size="0.15 0.15 0.15" rgba="0 1 0.4 0.5"/>
+    </body>
+
+    <body name="no_collide_C" pos="0.1 0 1.0">
+      <freejoint/>
+      <geom type="box" size="0.15 0.15 0.15" rgba="1 1 0 0.5"/>
+    </body>
+  </worldbody>
+
+  <contact>
+    <!-- test an invalid name for body1, but one that still mjcf parses -->
+    <exclude body1="world" body2="world"/>
+    <exclude body1="no_collide_A" body2="no_collide_B"/>
+    <exclude body1="no_collide_A" body2="no_collide_C"/>
+    <exclude body1="no_collide_B" body2="no_collide_C"/>
+  </contact>
+</mujoco>

--- a/tests/testExcludes.py
+++ b/tests/testExcludes.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+
+import usdex.core
+import usdex.test
+from pxr import Sdf, Tf, Usd, UsdPhysics
+
+import mujoco_usd_converter
+from tests.util.ConverterTestCase import ConverterTestCase
+
+
+class TestExcludes(ConverterTestCase):
+
+    def test_contact_excludes(self):
+        model_path = pathlib.Path("./tests/data/contact_excludes.xml")
+        model_name = model_path.stem
+
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Body 'world' or 'world' not found for contact exclude")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model_path, self.tmpDir())
+        stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+
+        # Test that the exclude is applied to the bodies
+        body1 = stage.GetPrimAtPath(f"/{model_name}/Geometry/no_collide_A")
+        self.assertTrue(body1.IsValid())
+        self.assertTrue(body1.HasAPI(UsdPhysics.FilteredPairsAPI))
+        filtered_pairs_api = UsdPhysics.FilteredPairsAPI(body1)
+        self.assertEqual(len(filtered_pairs_api.GetFilteredPairsRel().GetTargets()), 2)
+        self.assertEqual(filtered_pairs_api.GetFilteredPairsRel().GetTargets()[0], f"/{model_name}/Geometry/no_collide_B")
+        self.assertEqual(filtered_pairs_api.GetFilteredPairsRel().GetTargets()[1], f"/{model_name}/Geometry/no_collide_C")
+
+        body2 = stage.GetPrimAtPath(f"/{model_name}/Geometry/no_collide_B")
+        self.assertTrue(body2.IsValid())
+        self.assertTrue(body2.HasAPI(UsdPhysics.FilteredPairsAPI))
+        filtered_pairs_api = UsdPhysics.FilteredPairsAPI(body2)
+        self.assertEqual(len(filtered_pairs_api.GetFilteredPairsRel().GetTargets()), 1)
+        self.assertEqual(filtered_pairs_api.GetFilteredPairsRel().GetTargets()[0], f"/{model_name}/Geometry/no_collide_C")
+
+        # Test that the exclude is not applied to the bodies
+        body3 = stage.GetPrimAtPath(f"/{model_name}/Geometry/no_collide_C")
+        self.assertTrue(body3.IsValid())
+        self.assertFalse(body3.HasAPI(UsdPhysics.FilteredPairsAPI))


### PR DESCRIPTION
## Description
<!-- Set a descriptive pull request title. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues relevant to this PR. -->
Fixes #2 

- This uses the `UsdPhysicsFilteredPairsAPI` to exclude contacts between two bodies
- NOTE: MuJoCo simulate doesn't yet support decoding the `UsdPhysicsFilteredPairsAPI` schema as contact excludes yet.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
