### PR TITLE
Update menagerie annotations for MuJoCo Simulate

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -1,6 +1,6 @@
 # MuJoCo Menagerie Benchmark Report
 
-**Generated on:** 2026-02-27 07:03:58
+**Generated on:** 2026-03-09 14:05:46
 
 **Repository:** [https://github.com/google-deepmind/mujoco_menagerie.git](https://github.com/google-deepmind/mujoco_menagerie.git)
 
@@ -8,97 +8,97 @@
 
 | Total Models | Successful | Failed | Total Warnings | Total Errors | Average Time | Total Time | Total File Size |
 |:------------:|:----------:|:------:|:--------------:|:------------:|:------------:|:----------:|:---------------:|
-| 85 | 85 (100.0%) | 0 (0.0%) | 157 | 0 | 0.88s | 1m 14.82s | 395.73 MB |
+| 85 | 85 (100.0%) | 0 (0.0%) | 157 | 0 | 0.63s | 0m 53.17s | 396.24 MB |
 
 ## Detailed Results
 
 | Asset | Variant | Success | [Verified (Manual)](#manual-annotation-instructions) | [Verified In Newton (Manual)](#manual-annotation-instructions) | Errors | Warnings | Time (s) | Size (MB) | Notes | Error Messages | Warning Messages |
 |-------|---------|---------|----------|----------|-------:|--------:|---------:|---------:|----------------------|----------------|------------------|
-| **[agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper/)** | piper | ✅ | ❌ | ❓ | 0 | 2 | 2.33 | 8.34 | Most actuation in MuJoCo looks good, but the gripper is broken without equality constraints |  | lights are not supported<br>keys are not supported |
-| **[agility_cassie](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agility_cassie/)** | cassie | ✅ | ❓ | ❓ | 0 | 5 | 0.81 | 1.42 |  |  | Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'Ellipsoid'<br>cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
-| **[aloha](https://github.com/google-deepmind/mujoco_menagerie/tree/main/aloha/)** | aloha | ✅ | ❓ | ❓ | 0 | 3 | 0.63 | 3.05 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported |
-| **[anybotics_anymal_b](https://github.com/google-deepmind/mujoco_menagerie/tree/main/anybotics_anymal_b/)** | anymal_b | ✅ | ❓ | ❓ | 0 | 1 | 1.67 | 5.00 |  |  | lights are not supported |
-| **[anybotics_anymal_c](https://github.com/google-deepmind/mujoco_menagerie/tree/main/anybotics_anymal_c/)** | anymal_c | ✅ | ✅ | ❓ | 0 | 1 | 0.72 | 12.94 | Manual actuation in MuJoCo looks good |  | lights are not supported |
-|  | anymal_c_mjx | ✅ | ❓ | ❓ | 0 | 2 | 0.69 | 12.87 |  |  | cameras are not supported<br>keys are not supported |
-| **[apptronik_apollo](https://github.com/google-deepmind/mujoco_menagerie/tree/main/apptronik_apollo/)** | apptronik_apollo | ✅ | ❌ | ❓ | 0 | 4 | 1.31 | 28.54 | USD View looks good, and manual articulation in MuJoCo looks good, but without exclude pairs we cannot test actuation in MuJoCo as it falls through the ground plane |  | cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
-| **[arx_l5](https://github.com/google-deepmind/mujoco_menagerie/tree/main/arx_l5/)** | arx_l5 | ✅ | ❓ | ❓ | 0 | 3 | 0.91 | 2.02 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported |
-| **[berkeley_humanoid](https://github.com/google-deepmind/mujoco_menagerie/tree/main/berkeley_humanoid/)** | berkeley_humanoid | ✅ | ❓ | ❓ | 0 | 4 | 0.70 | 7.65 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
-| **[bitcraze_crazyflie_2](https://github.com/google-deepmind/mujoco_menagerie/tree/main/bitcraze_crazyflie_2/)** | cf2 | ✅ | ❓ | ❓ | 0 | 3 | 0.52 | 0.26 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
-| **[booster_t1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/booster_t1/)** | t1 | ✅ | ❓ | ❓ | 0 | 3 | 0.58 | 3.15 |  |  | lights are not supported<br>keys are not supported<br>sensors are not supported |
-| **[boston_dynamics_spot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/boston_dynamics_spot/)** | spot | ✅ | ❓ | ❓ | 0 | 2 | 1.28 | 6.44 |  |  | lights are not supported<br>keys are not supported |
-|  | spot_arm | ✅ | ❓ | ❓ | 0 | 2 | 1.56 | 8.72 |  |  | lights are not supported<br>keys are not supported |
-| **[dynamixel_2r](https://github.com/google-deepmind/mujoco_menagerie/tree/main/dynamixel_2r/)** | dynamixel_2r | ✅ | ❓ | ❓ | 0 | 0 | 0.57 | 1.54 |  |  |  |
-| **[flybody](https://github.com/google-deepmind/mujoco_menagerie/tree/main/flybody/)** | fruitfly | ✅ | ❓ | ❓ | 0 | 21 | 3.55 | 13.33 |  |  | Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'thorax_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'thorax_collision2'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'head_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rostrum_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'labrum_left_lower_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'labrum_right_lower_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_left_brown_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_left_membrane_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_left_fluid'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_right_brown_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_right_membrane_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_right_fluid'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T1_left_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T1_right_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T2_left_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T2_right_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T3_left_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T3_right_collision'<br>cameras are not supported<br>lights are not supported<br>sensors are not supported |
-| **[fourier_n1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/fourier_n1/)** | n1 | ✅ | ❓ | ❓ | 0 | 2 | 1.04 | 19.57 |  |  | lights are not supported<br>sensors are not supported |
-| **[franka_emika_panda](https://github.com/google-deepmind/mujoco_menagerie/tree/main/franka_emika_panda/)** | hand | ✅ | ❓ | ❓ | 0 | 0 | 0.48 | 0.43 |  |  |  |
-|  | mjx_panda | ✅ | ❓ | ❓ | 0 | 1 | 1.22 | 6.92 |  |  | lights are not supported |
-|  | mjx_panda_nohand | ✅ | ❓ | ❓ | 0 | 1 | 1.16 | 6.49 |  |  | lights are not supported |
-|  | panda | ✅ | ❓ | ❓ | 0 | 2 | 1.26 | 6.93 |  |  | lights are not supported<br>keys are not supported |
-|  | panda_nohand | ✅ | ❓ | ❓ | 0 | 2 | 1.16 | 6.50 |  |  | lights are not supported<br>keys are not supported |
-| **[franka_fr3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/franka_fr3/)** | fr3 | ✅ | ✅ | ❓ | 0 | 1 | 1.14 | 7.37 | Manual actuation in MuJoCo looks good |  | keys are not supported |
-| **[google_barkour_v0](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_barkour_v0/)** | barkour_v0 | ✅ | ✅ | ❓ | 0 | 3 | 0.56 | 3.48 | Manual actuation in MuJoCo looks good |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
-|  | barkour_v0_mjx | ✅ | ❓ | ❓ | 0 | 3 | 0.57 | 3.49 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
-| **[google_barkour_vb](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_barkour_vb/)** | barkour_vb | ✅ | ❓ | ❓ | 0 | 2 | 0.51 | 1.66 |  |  | cameras are not supported<br>sensors are not supported |
-|  | barkour_vb_mjx | ✅ | ❓ | ❓ | 0 | 2 | 0.51 | 1.65 |  |  | cameras are not supported<br>sensors are not supported |
-| **[google_robot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_robot/)** | robot | ✅ | ❓ | ❓ | 0 | 1 | 0.60 | 2.82 |  |  | lights are not supported |
-| **[hello_robot_stretch](https://github.com/google-deepmind/mujoco_menagerie/tree/main/hello_robot_stretch/)** | stretch | ✅ | ❓ | ❓ | 0 | 1 | 2.15 | 11.93 |  |  | cameras are not supported |
-| **[hello_robot_stretch_3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/hello_robot_stretch_3/)** | stretch | ✅ | ❓ | ❓ | 0 | 3 | 2.27 | 12.80 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
-| **[i2rt_yam](https://github.com/google-deepmind/mujoco_menagerie/tree/main/i2rt_yam/)** | yam | ✅ | ❓ | ❓ | 0 | 2 | 0.55 | 1.78 |  |  | lights are not supported<br>keys are not supported |
-| **[iit_softfoot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/iit_softfoot/)** | softfoot | ✅ | ❓ | ❓ | 0 | 0 | 0.96 | 2.08 |  |  |  |
-| **[kinova_gen3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kinova_gen3/)** | gen3 | ✅ | ❓ | ❓ | 0 | 2 | 0.49 | 1.60 |  |  | cameras are not supported<br>keys are not supported |
-| **[kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14/)** | iiwa14 | ✅ | ❓ | ❓ | 0 | 2 | 0.62 | 1.42 |  |  | lights are not supported<br>keys are not supported |
-| **[leap_hand](https://github.com/google-deepmind/mujoco_menagerie/tree/main/leap_hand/)** | left_hand | ✅ | ❓ | ❓ | 0 | 3 | 0.87 | 2.57 |  |  | "distal.obj" contains multiple meshes, only the first one will be converted<br>"thumb_distal.obj" contains multiple meshes, only the first one will be converted<br>sensors are not supported |
-|  | right_hand | ✅ | ❓ | ❓ | 0 | 3 | 0.81 | 2.15 |  |  | "distal.obj" contains multiple meshes, only the first one will be converted<br>"thumb_distal.obj" contains multiple meshes, only the first one will be converted<br>sensors are not supported |
-| **[low_cost_robot_arm](https://github.com/google-deepmind/mujoco_menagerie/tree/main/low_cost_robot_arm/)** | low_cost_robot_arm | ✅ | ❓ | ❓ | 0 | 1 | 0.51 | 2.33 |  |  | keys are not supported |
-| **[pal_talos](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_talos/)** | talos | ✅ | ❓ | ❓ | 0 | 0 | 0.79 | 3.45 |  |  |  |
-|  | talos_motor | ✅ | ❓ | ❓ | 0 | 1 | 0.81 | 3.46 |  |  | keys are not supported |
-|  | talos_position | ✅ | ❓ | ❓ | 0 | 1 | 0.82 | 3.47 |  |  | keys are not supported |
-| **[pal_tiago](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_tiago/)** | tiago | ✅ | ❓ | ❓ | 0 | 1 | 0.56 | 2.14 |  |  | cameras are not supported |
-|  | tiago_motor | ✅ | ❓ | ❓ | 0 | 1 | 0.55 | 2.15 |  |  | cameras are not supported |
-|  | tiago_position | ✅ | ❓ | ❓ | 0 | 2 | 0.55 | 2.15 |  |  | cameras are not supported<br>keys are not supported |
-|  | tiago_velocity | ✅ | ❓ | ❓ | 0 | 2 | 0.55 | 2.15 |  |  | cameras are not supported<br>keys are not supported |
-| **[pal_tiago_dual](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_tiago_dual/)** | tiago_dual | ✅ | ❓ | ❓ | 0 | 0 | 0.61 | 2.71 |  |  |  |
-|  | tiago_dual_motor | ✅ | ❓ | ❓ | 0 | 0 | 0.62 | 2.72 |  |  |  |
-|  | tiago_dual_position | ✅ | ❓ | ❓ | 0 | 0 | 0.62 | 2.72 |  |  |  |
-|  | tiago_dual_velocity | ✅ | ❓ | ❓ | 0 | 0 | 0.62 | 2.72 |  |  |  |
-| **[pndbotics_adam_lite](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pndbotics_adam_lite/)** | adam_lite | ✅ | ❓ | ❓ | 0 | 0 | 3.80 | 22.17 |  |  |  |
-| **[realsense_d435i](https://github.com/google-deepmind/mujoco_menagerie/tree/main/realsense_d435i/)** | d435i | ✅ | ❓ | ❓ | 0 | 1 | 2.74 | 7.73 |  |  | lights are not supported |
-| **[rethink_robotics_sawyer](https://github.com/google-deepmind/mujoco_menagerie/tree/main/rethink_robotics_sawyer/)** | sawyer | ✅ | ❓ | ❓ | 0 | 2 | 1.19 | 6.67 |  |  | lights are not supported<br>keys are not supported |
-| **[robot_soccer_kit](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robot_soccer_kit/)** | robot_soccer_kit | ✅ | ❓ | ❓ | 0 | 0 | 1.05 | 2.49 |  |  |  |
-| **[robotiq_2f85](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotiq_2f85/)** | 2f85 | ✅ | ❓ | ❓ | 0 | 0 | 0.50 | 1.03 |  |  |  |
-| **[robotiq_2f85_v4](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotiq_2f85_v4/)** | 2f85 | ✅ | ❓ | ❓ | 0 | 0 | 0.52 | 1.93 |  |  |  |
-|  | mjx_2f85 | ✅ | ❓ | ❓ | 0 | 0 | 0.50 | 1.92 |  |  |  |
-| **[robotis_op3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotis_op3/)** | op3 | ✅ | ❓ | ❓ | 0 | 2 | 0.89 | 11.26 |  |  | cameras are not supported<br>lights are not supported |
-| **[shadow_dexee](https://github.com/google-deepmind/mujoco_menagerie/tree/main/shadow_dexee/)** | shadow_dexee | ✅ | ❓ | ❓ | 0 | 2 | 0.70 | 2.30 |  |  | lights are not supported<br>sensors are not supported |
-| **[shadow_hand](https://github.com/google-deepmind/mujoco_menagerie/tree/main/shadow_hand/)** | left_hand | ✅ | ❓ | ❓ | 0 | 0 | 0.62 | 0.93 |  |  |  |
-|  | right_hand | ✅ | ❓ | ❓ | 0 | 0 | 0.61 | 0.93 |  |  |  |
-| **[skydio_x2](https://github.com/google-deepmind/mujoco_menagerie/tree/main/skydio_x2/)** | x2 | ✅ | ❓ | ❓ | 0 | 9 | 0.42 | 0.39 |  |  | Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor1'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor2'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor3'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor4'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'Ellipsoid'<br>cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
-| **[stanford_tidybot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/stanford_tidybot/)** | base | ✅ | ❓ | ❓ | 0 | 0 | 0.42 | 0.09 |  |  |  |
-|  | tidybot | ✅ | ❓ | ❓ | 0 | 2 | 0.57 | 2.44 |  |  | cameras are not supported<br>keys are not supported |
-| **[trossen_vx300s](https://github.com/google-deepmind/mujoco_menagerie/tree/main/trossen_vx300s/)** | vx300s | ✅ | ❓ | ❓ | 0 | 2 | 0.49 | 0.51 |  |  | lights are not supported<br>keys are not supported |
-| **[trossen_wx250s](https://github.com/google-deepmind/mujoco_menagerie/tree/main/trossen_wx250s/)** | wx250s | ✅ | ❓ | ❓ | 0 | 2 | 0.46 | 0.26 |  |  | lights are not supported<br>keys are not supported |
-| **[trs_so_arm100](https://github.com/google-deepmind/mujoco_menagerie/tree/main/trs_so_arm100/)** | so_arm100 | ✅ | ❓ | ❓ | 0 | 1 | 0.49 | 1.02 |  |  | keys are not supported |
-| **[ufactory_lite6](https://github.com/google-deepmind/mujoco_menagerie/tree/main/ufactory_lite6/)** | lite6 | ✅ | ❓ | ❓ | 0 | 1 | 0.46 | 1.21 |  |  | keys are not supported |
-|  | lite6_gripper_narrow | ✅ | ❓ | ❓ | 0 | 1 | 0.49 | 1.38 |  |  | keys are not supported |
-|  | lite6_gripper_wide | ✅ | ❓ | ❓ | 0 | 1 | 0.49 | 1.40 |  |  | keys are not supported |
-| **[ufactory_xarm7](https://github.com/google-deepmind/mujoco_menagerie/tree/main/ufactory_xarm7/)** | hand | ✅ | ❓ | ❓ | 0 | 0 | 0.45 | 0.71 |  |  |  |
-|  | xarm7 | ✅ | ❓ | ❓ | 0 | 1 | 0.50 | 1.52 |  |  | keys are not supported |
-|  | xarm7_nohand | ✅ | ❓ | ❓ | 0 | 1 | 0.44 | 0.79 |  |  | keys are not supported |
-| **[umi_gripper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/umi_gripper/)** | umi_gripper | ✅ | ❓ | ❓ | 0 | 3 | 0.47 | 0.76 |  |  | Binding a textured Material '/umi_gripper/Materials/Left_Aruco_Base_Sticker' to a Cube Prim ('/umi_gripper/Geometry/Body/left_finger_holder/left_marker') will discard textures at render time.<br>Binding a textured Material '/umi_gripper/Materials/Right_Aruco_Base_Sticker' to a Cube Prim ('/umi_gripper/Geometry/Body/right_finger_holder/right_marker') will discard textures at render time.<br>cameras are not supported |
-| **[unitree_a1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_a1/)** | a1 | ✅ | ❓ | ❓ | 0 | 2 | 0.90 | 4.00 |  |  | lights are not supported<br>keys are not supported |
-| **[unitree_g1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_g1/)** | g1 | ✅ | ❓ | ❓ | 0 | 3 | 0.77 | 7.87 |  |  | lights are not supported<br>keys are not supported<br>sensors are not supported |
-|  | g1_mjx | ✅ | ❓ | ❓ | 0 | 3 | 0.74 | 7.85 |  |  | cameras are not supported<br>lights are not supported<br>sensors are not supported |
-|  | g1_with_hands | ✅ | ❓ | ❓ | 0 | 3 | 0.94 | 10.56 |  |  | lights are not supported<br>keys are not supported<br>sensors are not supported |
-| **[unitree_go1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_go1/)** | go1 | ✅ | ❓ | ❓ | 0 | 3 | 0.60 | 2.74 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported |
-| **[unitree_go2](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_go2/)** | go2 | ✅ | ❓ | ❓ | 0 | 1 | 1.18 | 6.33 |  |  | keys are not supported |
-|  | go2_mjx | ✅ | ❓ | ❓ | 0 | 3 | 1.18 | 6.34 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
-| **[unitree_h1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_h1/)** | h1 | ✅ | ❓ | ❓ | 0 | 1 | 0.64 | 5.44 |  |  | lights are not supported |
-| **[unitree_z1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_z1/)** | z1 | ✅ | ❓ | ❓ | 0 | 1 | 0.51 | 3.41 |  |  | keys are not supported |
-|  | z1_gripper | ✅ | ❓ | ❓ | 0 | 1 | 0.57 | 4.72 |  |  | keys are not supported |
-| **[universal_robots_ur10e](https://github.com/google-deepmind/mujoco_menagerie/tree/main/universal_robots_ur10e/)** | ur10e | ✅ | ❓ | ❓ | 0 | 2 | 1.08 | 6.54 |  |  | lights are not supported<br>keys are not supported |
-| **[universal_robots_ur5e](https://github.com/google-deepmind/mujoco_menagerie/tree/main/universal_robots_ur5e/)** | ur5e | ✅ | ❓ | ❓ | 0 | 2 | 1.05 | 6.11 |  |  | lights are not supported<br>keys are not supported |
-| **[wonik_allegro](https://github.com/google-deepmind/mujoco_menagerie/tree/main/wonik_allegro/)** | left_hand | ✅ | ❓ | ❓ | 0 | 0 | 0.51 | 0.50 |  |  |  |
-|  | right_hand | ✅ | ❓ | ❓ | 0 | 0 | 0.51 | 0.40 |  |  |  |
+| **[agilex_piper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agilex_piper/)** | piper | ✅ | ✅ | ❓ | 0 | 2 | 1.19 | 8.30 |  |  | lights are not supported<br>keys are not supported |
+| **[agility_cassie](https://github.com/google-deepmind/mujoco_menagerie/tree/main/agility_cassie/)** | cassie | ✅ | ✅ | ❓ | 0 | 5 | 0.59 | 1.44 | One of the legs on the USD model has inverted triangles, but it seems to behave similarly to the original model |  | Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'Ellipsoid'<br>cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
+| **[aloha](https://github.com/google-deepmind/mujoco_menagerie/tree/main/aloha/)** | aloha | ✅ | ✅ | ❓ | 0 | 3 | 0.49 | 3.05 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported |
+| **[anybotics_anymal_b](https://github.com/google-deepmind/mujoco_menagerie/tree/main/anybotics_anymal_b/)** | anymal_b | ✅ | ✅ | ❓ | 0 | 1 | 1.11 | 5.00 |  |  | lights are not supported |
+| **[anybotics_anymal_c](https://github.com/google-deepmind/mujoco_menagerie/tree/main/anybotics_anymal_c/)** | anymal_c | ✅ | ✅ | ❓ | 0 | 1 | 0.55 | 12.97 | Manual actuation in MuJoCo looks good |  | lights are not supported |
+|  | anymal_c_mjx | ✅ | ✅ | ❓ | 0 | 2 | 0.52 | 12.89 |  |  | cameras are not supported<br>keys are not supported |
+| **[apptronik_apollo](https://github.com/google-deepmind/mujoco_menagerie/tree/main/apptronik_apollo/)** | apptronik_apollo | ✅ | ❌ | ❓ | 0 | 4 | 0.93 | 28.62 | USD View looks good, and manual articulation in MuJoCo looks good, but without contact pairs we cannot test actuation in MuJoCo as it falls through the ground plane |  | cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
+| **[arx_l5](https://github.com/google-deepmind/mujoco_menagerie/tree/main/arx_l5/)** | arx_l5 | ✅ | ✅ | ❓ | 0 | 3 | 0.60 | 2.01 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported |
+| **[berkeley_humanoid](https://github.com/google-deepmind/mujoco_menagerie/tree/main/berkeley_humanoid/)** | berkeley_humanoid | ✅ | ✅ | ❓ | 0 | 4 | 0.54 | 7.65 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
+| **[bitcraze_crazyflie_2](https://github.com/google-deepmind/mujoco_menagerie/tree/main/bitcraze_crazyflie_2/)** | cf2 | ✅ | ✅ | ❓ | 0 | 3 | 0.40 | 0.26 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
+| **[booster_t1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/booster_t1/)** | t1 | ✅ | ✅ | ❓ | 0 | 3 | 0.43 | 3.16 |  |  | lights are not supported<br>keys are not supported<br>sensors are not supported |
+| **[boston_dynamics_spot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/boston_dynamics_spot/)** | spot | ✅ | ✅ | ❓ | 0 | 2 | 0.93 | 6.45 |  |  | lights are not supported<br>keys are not supported |
+|  | spot_arm | ✅ | ✅ | ❓ | 0 | 2 | 1.07 | 8.74 |  |  | lights are not supported<br>keys are not supported |
+| **[dynamixel_2r](https://github.com/google-deepmind/mujoco_menagerie/tree/main/dynamixel_2r/)** | dynamixel_2r | ✅ | ✅ | ❓ | 0 | 0 | 0.45 | 1.59 |  |  |  |
+| **[flybody](https://github.com/google-deepmind/mujoco_menagerie/tree/main/flybody/)** | fruitfly | ✅ | ❌ | ❓ | 0 | 21 | 2.28 | 13.33 | Many of the actuators in the USD model are not working properly in MuJoCo Simulate |  | Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'thorax_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'thorax_collision2'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'head_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rostrum_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'labrum_left_lower_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'labrum_right_lower_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_left_brown_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_left_membrane_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_left_fluid'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_right_brown_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_right_membrane_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'wing_right_fluid'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T1_left_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T1_right_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T2_left_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T2_right_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T3_left_collision'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'coxa_T3_right_collision'<br>cameras are not supported<br>lights are not supported<br>sensors are not supported |
+| **[fourier_n1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/fourier_n1/)** | n1 | ✅ | ✅ | ❓ | 0 | 2 | 0.80 | 19.59 |  |  | lights are not supported<br>sensors are not supported |
+| **[franka_emika_panda](https://github.com/google-deepmind/mujoco_menagerie/tree/main/franka_emika_panda/)** | hand | ✅ | ✅ | ❓ | 0 | 0 | 0.38 | 0.43 |  |  |  |
+|  | mjx_panda | ✅ | ✅ | ❓ | 0 | 1 | 0.89 | 6.97 | The group 3 collision shapes are visible in MuJoCo Simulate, but it behaves correctly |  | lights are not supported |
+|  | mjx_panda_nohand | ✅ | ✅ | ❓ | 0 | 1 | 0.85 | 6.52 |  |  | lights are not supported |
+|  | panda | ✅ | ✅ | ❓ | 0 | 2 | 0.87 | 6.97 |  |  | lights are not supported<br>keys are not supported |
+|  | panda_nohand | ✅ | ✅ | ❓ | 0 | 2 | 0.83 | 6.53 |  |  | lights are not supported<br>keys are not supported |
+| **[franka_fr3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/franka_fr3/)** | fr3 | ✅ | ✅ | ❓ | 0 | 1 | 0.84 | 7.39 | Manual actuation in MuJoCo looks good |  | keys are not supported |
+| **[google_barkour_v0](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_barkour_v0/)** | barkour_v0 | ✅ | ✅ | ❓ | 0 | 3 | 0.45 | 3.48 | Manual actuation in MuJoCo looks good |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
+|  | barkour_v0_mjx | ✅ | ✅ | ❓ | 0 | 3 | 0.45 | 3.48 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
+| **[google_barkour_vb](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_barkour_vb/)** | barkour_vb | ✅ | ✅ | ❓ | 0 | 2 | 0.41 | 1.66 |  |  | cameras are not supported<br>sensors are not supported |
+|  | barkour_vb_mjx | ✅ | ✅ | ❓ | 0 | 2 | 0.39 | 1.66 |  |  | cameras are not supported<br>sensors are not supported |
+| **[google_robot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/google_robot/)** | robot | ✅ | ❌ | ❓ | 0 | 1 | 0.46 | 2.83 | The shoulder actuator from the USD model is weaker in MuJoCo Simulate, possibly due to how the position-based actuators decoded to general actuators |  | lights are not supported |
+| **[hello_robot_stretch](https://github.com/google-deepmind/mujoco_menagerie/tree/main/hello_robot_stretch/)** | stretch | ✅ | ❌ | ❓ | 0 | 1 | 1.50 | 11.94 | The lift actuator does not work properly in MuJoCo Simulate |  | cameras are not supported |
+| **[hello_robot_stretch_3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/hello_robot_stretch_3/)** | stretch | ✅ | ❌ | ❓ | 0 | 3 | 1.51 | 12.80 | The lift actuator does not work properly in MuJoCo Simulate |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
+| **[i2rt_yam](https://github.com/google-deepmind/mujoco_menagerie/tree/main/i2rt_yam/)** | yam | ✅ | ✅ | ❓ | 0 | 2 | 0.42 | 1.77 |  |  | lights are not supported<br>keys are not supported |
+| **[iit_softfoot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/iit_softfoot/)** | softfoot | ✅ | ❌ | ❓ | 0 | 0 | 0.57 | 2.00 | scene.xml uses body/attach, causing issues with conversion. The model itself is slightly jittery in MuJoCo |  |  |
+| **[kinova_gen3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kinova_gen3/)** | gen3 | ✅ | ✅ | ❓ | 0 | 2 | 0.40 | 1.60 |  |  | cameras are not supported<br>keys are not supported |
+| **[kuka_iiwa_14](https://github.com/google-deepmind/mujoco_menagerie/tree/main/kuka_iiwa_14/)** | iiwa14 | ✅ | ✅ | ❓ | 0 | 2 | 0.45 | 1.43 |  |  | lights are not supported<br>keys are not supported |
+| **[leap_hand](https://github.com/google-deepmind/mujoco_menagerie/tree/main/leap_hand/)** | left_hand | ✅ | ✅ | ❓ | 0 | 3 | 0.61 | 2.56 |  |  | "distal.obj" contains multiple meshes, only the first one will be converted<br>"thumb_distal.obj" contains multiple meshes, only the first one will be converted<br>sensors are not supported |
+|  | right_hand | ✅ | ✅ | ❓ | 0 | 3 | 0.59 | 2.14 |  |  | "distal.obj" contains multiple meshes, only the first one will be converted<br>"thumb_distal.obj" contains multiple meshes, only the first one will be converted<br>sensors are not supported |
+| **[low_cost_robot_arm](https://github.com/google-deepmind/mujoco_menagerie/tree/main/low_cost_robot_arm/)** | low_cost_robot_arm | ✅ | ✅ | ❓ | 0 | 1 | 0.41 | 2.34 |  |  | keys are not supported |
+| **[pal_talos](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_talos/)** | talos | ✅ | ✅ | ❓ | 0 | 0 | 0.53 | 3.42 |  |  |  |
+|  | talos_motor | ✅ | ✅ | ❓ | 0 | 1 | 0.53 | 3.43 |  |  | keys are not supported |
+|  | talos_position | ✅ | ✅ | ❓ | 0 | 1 | 0.56 | 3.44 |  |  | keys are not supported |
+| **[pal_tiago](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_tiago/)** | tiago | ✅ | ✅ | ❓ | 0 | 1 | 0.41 | 2.14 |  |  | cameras are not supported |
+|  | tiago_motor | ✅ | ✅ | ❓ | 0 | 1 | 0.43 | 2.15 |  |  | cameras are not supported |
+|  | tiago_position | ✅ | ✅ | ❓ | 0 | 2 | 0.43 | 2.15 |  |  | cameras are not supported<br>keys are not supported |
+|  | tiago_velocity | ✅ | ✅ | ❓ | 0 | 2 | 0.43 | 2.15 |  |  | cameras are not supported<br>keys are not supported |
+| **[pal_tiago_dual](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pal_tiago_dual/)** | tiago_dual | ✅ | ✅ | ❓ | 0 | 0 | 0.45 | 2.71 |  |  |  |
+|  | tiago_dual_motor | ✅ | ✅ | ❓ | 0 | 0 | 0.46 | 2.72 |  |  |  |
+|  | tiago_dual_position | ✅ | ✅ | ❓ | 0 | 0 | 0.47 | 2.72 |  |  |  |
+|  | tiago_dual_velocity | ✅ | ✅ | ❓ | 0 | 0 | 0.45 | 2.72 |  |  |  |
+| **[pndbotics_adam_lite](https://github.com/google-deepmind/mujoco_menagerie/tree/main/pndbotics_adam_lite/)** | adam_lite | ✅ | ❓ | ❓ | 0 | 0 | 2.39 | 22.13 | We do not apply the schema with inertia to visual geoms, thus the model does not open in MuJoCo Simulate |  |  |
+| **[realsense_d435i](https://github.com/google-deepmind/mujoco_menagerie/tree/main/realsense_d435i/)** | d435i | ✅ | ✅ | ❓ | 0 | 1 | 1.93 | 7.73 |  |  | lights are not supported |
+| **[rethink_robotics_sawyer](https://github.com/google-deepmind/mujoco_menagerie/tree/main/rethink_robotics_sawyer/)** | sawyer | ✅ | ✅ | ❓ | 0 | 2 | 0.85 | 6.70 |  |  | lights are not supported<br>keys are not supported |
+| **[robot_soccer_kit](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robot_soccer_kit/)** | robot_soccer_kit | ✅ | ✅ | ❓ | 0 | 0 | 0.74 | 2.65 |  |  |  |
+| **[robotiq_2f85](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotiq_2f85/)** | 2f85 | ✅ | ✅ | ❓ | 0 | 0 | 0.39 | 1.04 |  |  |  |
+| **[robotiq_2f85_v4](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotiq_2f85_v4/)** | 2f85 | ✅ | ✅ | ❓ | 0 | 0 | 0.40 | 1.94 |  |  |  |
+|  | mjx_2f85 | ✅ | ❓ | ❓ | 0 | 0 | 0.39 | 1.93 | The left and right follower bodies collide with the base due to unsupported collision filtering via the `contype` & `conaffinity` in the MJCF model |  |  |
+| **[robotis_op3](https://github.com/google-deepmind/mujoco_menagerie/tree/main/robotis_op3/)** | op3 | ✅ | ✅ | ❓ | 0 | 2 | 0.66 | 11.27 |  |  | cameras are not supported<br>lights are not supported |
+| **[shadow_dexee](https://github.com/google-deepmind/mujoco_menagerie/tree/main/shadow_dexee/)** | shadow_dexee | ✅ | ❓ | ❓ | 0 | 2 | 0.48 | 2.30 | The mujoco model itself will not load in MuJoCo Simulate: plugin mujoco.pid not found |  | lights are not supported<br>sensors are not supported |
+| **[shadow_hand](https://github.com/google-deepmind/mujoco_menagerie/tree/main/shadow_hand/)** | left_hand | ✅ | ✅ | ❓ | 0 | 0 | 0.46 | 0.95 |  |  |  |
+|  | right_hand | ✅ | ✅ | ❓ | 0 | 0 | 0.45 | 0.95 |  |  |  |
+| **[skydio_x2](https://github.com/google-deepmind/mujoco_menagerie/tree/main/skydio_x2/)** | x2 | ✅ | ✅ | ❓ | 0 | 9 | 0.33 | 0.39 | Collision on the rotor bodies not correct, possibly due to the ellipsoid geoms |  | Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor1'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor2'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor3'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'rotor4'<br>Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'Ellipsoid'<br>cameras are not supported<br>lights are not supported<br>keys are not supported<br>sensors are not supported |
+| **[stanford_tidybot](https://github.com/google-deepmind/mujoco_menagerie/tree/main/stanford_tidybot/)** | base | ✅ | ✅ | ❓ | 0 | 0 | 0.33 | 0.09 |  |  |  |
+|  | tidybot | ✅ | ✅ | ❓ | 0 | 2 | 0.45 | 2.46 |  |  | cameras are not supported<br>keys are not supported |
+| **[trossen_vx300s](https://github.com/google-deepmind/mujoco_menagerie/tree/main/trossen_vx300s/)** | vx300s | ✅ | ✅ | ❓ | 0 | 2 | 0.36 | 0.50 |  |  | lights are not supported<br>keys are not supported |
+| **[trossen_wx250s](https://github.com/google-deepmind/mujoco_menagerie/tree/main/trossen_wx250s/)** | wx250s | ✅ | ✅ | ❓ | 0 | 2 | 0.35 | 0.26 | The original model gripper does not work properly, the USD converted model behaves the same |  | lights are not supported<br>keys are not supported |
+| **[trs_so_arm100](https://github.com/google-deepmind/mujoco_menagerie/tree/main/trs_so_arm100/)** | so_arm100 | ✅ | ✅ | ❓ | 0 | 1 | 0.39 | 1.02 |  |  | keys are not supported |
+| **[ufactory_lite6](https://github.com/google-deepmind/mujoco_menagerie/tree/main/ufactory_lite6/)** | lite6 | ✅ | ✅ | ❓ | 0 | 1 | 0.37 | 1.22 |  |  | keys are not supported |
+|  | lite6_gripper_narrow | ✅ | ✅ | ❓ | 0 | 1 | 0.39 | 1.38 |  |  | keys are not supported |
+|  | lite6_gripper_wide | ✅ | ✅ | ❓ | 0 | 1 | 0.40 | 1.41 |  |  | keys are not supported |
+| **[ufactory_xarm7](https://github.com/google-deepmind/mujoco_menagerie/tree/main/ufactory_xarm7/)** | hand | ✅ | ✅ | ❓ | 0 | 0 | 0.33 | 0.72 |  |  |  |
+|  | xarm7 | ✅ | ✅ | ❓ | 0 | 1 | 0.39 | 1.52 |  |  | keys are not supported |
+|  | xarm7_nohand | ✅ | ✅ | ❓ | 0 | 1 | 0.35 | 0.79 |  |  | keys are not supported |
+| **[umi_gripper](https://github.com/google-deepmind/mujoco_menagerie/tree/main/umi_gripper/)** | umi_gripper | ✅ | ✅ | ❓ | 0 | 3 | 0.37 | 0.76 |  |  | Binding a textured Material '/umi_gripper/Materials/Left_Aruco_Base_Sticker' to a Cube Prim ('/umi_gripper/Geometry/Body/left_finger_holder/left_marker') will discard textures at render time.<br>Binding a textured Material '/umi_gripper/Materials/Right_Aruco_Base_Sticker' to a Cube Prim ('/umi_gripper/Geometry/Body/right_finger_holder/right_marker') will discard textures at render time.<br>cameras are not supported |
+| **[unitree_a1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_a1/)** | a1 | ✅ | ✅ | ❓ | 0 | 2 | 0.64 | 4.01 |  |  | lights are not supported<br>keys are not supported |
+| **[unitree_g1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_g1/)** | g1 | ✅ | ✅ | ❓ | 0 | 3 | 0.53 | 7.85 |  |  | lights are not supported<br>keys are not supported<br>sensors are not supported |
+|  | g1_mjx | ✅ | ❓ | ❓ | 0 | 3 | 0.52 | 7.84 | Some of the collision volumes are visible in green in MuJoCo Simulate |  | cameras are not supported<br>lights are not supported<br>sensors are not supported |
+|  | g1_with_hands | ✅ | ✅ | ❓ | 0 | 3 | 0.62 | 10.53 |  |  | lights are not supported<br>keys are not supported<br>sensors are not supported |
+| **[unitree_go1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_go1/)** | go1 | ✅ | ✅ | ❓ | 0 | 3 | 0.44 | 2.75 |  |  | cameras are not supported<br>lights are not supported<br>keys are not supported |
+| **[unitree_go2](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_go2/)** | go2 | ✅ | ✅ | ❓ | 0 | 1 | 0.83 | 6.36 |  |  | keys are not supported |
+|  | go2_mjx | ✅ | ✅ | ❓ | 0 | 3 | 0.79 | 6.36 |  |  | cameras are not supported<br>keys are not supported<br>sensors are not supported |
+| **[unitree_h1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_h1/)** | h1 | ✅ | ✅ | ❓ | 0 | 1 | 0.48 | 5.45 |  |  | lights are not supported |
+| **[unitree_z1](https://github.com/google-deepmind/mujoco_menagerie/tree/main/unitree_z1/)** | z1 | ✅ | ✅ | ❓ | 0 | 1 | 0.40 | 3.41 |  |  | keys are not supported |
+|  | z1_gripper | ✅ | ✅ | ❓ | 0 | 1 | 0.43 | 4.72 | Note that the original model gripper shakes in MuJoCo Simulate, the USD model behaves the same |  | keys are not supported |
+| **[universal_robots_ur10e](https://github.com/google-deepmind/mujoco_menagerie/tree/main/universal_robots_ur10e/)** | ur10e | ✅ | ✅ | ❓ | 0 | 2 | 0.74 | 6.55 |  |  | lights are not supported<br>keys are not supported |
+| **[universal_robots_ur5e](https://github.com/google-deepmind/mujoco_menagerie/tree/main/universal_robots_ur5e/)** | ur5e | ✅ | ✅ | ❓ | 0 | 2 | 0.70 | 6.12 |  |  | lights are not supported<br>keys are not supported |
+| **[wonik_allegro](https://github.com/google-deepmind/mujoco_menagerie/tree/main/wonik_allegro/)** | left_hand | ✅ | ✅ | ❓ | 0 | 0 | 0.38 | 0.50 |  |  |  |
+|  | right_hand | ✅ | ✅ | ❓ | 0 | 0 | 0.39 | 0.40 |  |  |  |
 
 
 ## Manual Annotation Instructions

--- a/tools/menagerie_annotations.yaml
+++ b/tools/menagerie_annotations.yaml
@@ -35,8 +35,8 @@ agilex_piper:
     evaluator: 'andrewkaufman'
     filename: piper.xml
     model_name: piper
-    notes: 'Most actuation in MuJoCo looks good, but the gripper is broken without equality constraints'
-    verified: 'No'
+    notes: ''
+    verified: 'Yes'
     verified_in_newton: 'Unknown'
 agility_cassie:
   _metadata:
@@ -70,7 +70,7 @@ aloha:
     filename: aloha.xml
     model_name: aloha
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 anybotics_anymal_b:
   _metadata:
@@ -87,7 +87,7 @@ anybotics_anymal_b:
     filename: anymal_b.xml
     model_name: anymal_b
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 anybotics_anymal_c:
   _metadata:
@@ -129,7 +129,7 @@ apptronik_apollo:
     evaluator: 'andrewkaufman'
     filename: apptronik_apollo.xml
     model_name: apptronik_apollo
-    notes: 'USD View looks good, and manual articulation in MuJoCo looks good, but without exclude pairs we cannot test actuation in MuJoCo as it falls through the ground plane'
+    notes: 'USD View looks good, and manual articulation in MuJoCo looks good, but without contact pairs we cannot test actuation in MuJoCo as it falls through the ground plane'
     verified: 'No'
     verified_in_newton: Unknown
 arx_l5:
@@ -147,7 +147,7 @@ arx_l5:
     filename: arx_l5.xml
     model_name: arx_l5
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 berkeley_humanoid:
   _metadata:
@@ -164,7 +164,7 @@ berkeley_humanoid:
     filename: berkeley_humanoid.xml
     model_name: berkeley_humanoid
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 bitcraze_crazyflie_2:
   _metadata:
@@ -181,7 +181,7 @@ bitcraze_crazyflie_2:
     filename: cf2.xml
     model_name: cf2
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 booster_t1:
   _metadata:
@@ -198,7 +198,7 @@ booster_t1:
     filename: t1.xml
     model_name: t1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 boston_dynamics_spot:
   _metadata:
@@ -215,7 +215,7 @@ boston_dynamics_spot:
     filename: spot.xml
     model_name: spot
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: boston_dynamics_spot
     description: 'Model variant: spot_arm'
@@ -224,7 +224,7 @@ boston_dynamics_spot:
     filename: spot_arm.xml
     model_name: spot_arm
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 dynamixel_2r:
   _metadata:
@@ -241,7 +241,7 @@ dynamixel_2r:
     filename: dynamixel_2r.xml
     model_name: dynamixel_2r
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 flybody:
   _metadata:
@@ -275,7 +275,7 @@ fourier_n1:
     filename: n1.xml
     model_name: n1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 franka_emika_panda:
   _metadata:
@@ -292,7 +292,7 @@ franka_emika_panda:
     filename: hand.xml
     model_name: hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: panda_nohand'
@@ -301,7 +301,7 @@ franka_emika_panda:
     filename: panda_nohand.xml
     model_name: panda_nohand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: mjx_panda'
@@ -309,8 +309,8 @@ franka_emika_panda:
     evaluator: ''
     filename: mjx_panda.xml
     model_name: mjx_panda
-    notes: ''
-    verified: Unknown
+    notes: 'TODO: There are strange shapes in MuJoCo, but it behaves correctly'
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: panda'
@@ -319,7 +319,7 @@ franka_emika_panda:
     filename: panda.xml
     model_name: panda
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: mjx_panda_nohand'
@@ -328,7 +328,7 @@ franka_emika_panda:
     filename: mjx_panda_nohand.xml
     model_name: mjx_panda_nohand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 franka_fr3:
   _metadata:
@@ -362,7 +362,7 @@ google_barkour_v0:
     filename: barkour_v0_mjx.xml
     model_name: barkour_v0_mjx
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: google_barkour_v0
     description: 'Model variant: barkour_v0'
@@ -388,7 +388,7 @@ google_barkour_vb:
     filename: barkour_vb.xml
     model_name: barkour_vb
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: google_barkour_vb
     description: 'Model variant: barkour_vb_mjx'
@@ -397,7 +397,7 @@ google_barkour_vb:
     filename: barkour_vb_mjx.xml
     model_name: barkour_vb_mjx
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 google_robot:
   _metadata:
@@ -413,8 +413,8 @@ google_robot:
     evaluator: ''
     filename: robot.xml
     model_name: robot
-    notes: ''
-    verified: Unknown
+    notes: 'TODO: It behaves similarly in MuJoCo, but the joints are not exactly the same'
+    verified: 'Yes'
     verified_in_newton: Unknown
 hello_robot_stretch:
   _metadata:
@@ -430,8 +430,8 @@ hello_robot_stretch:
     evaluator: ''
     filename: stretch.xml
     model_name: stretch
-    notes: ''
-    verified: Unknown
+    notes: 'TODO: The lift actuator doesn't work properly in MuJoCo'
+    verified: 'No'
     verified_in_newton: Unknown
 hello_robot_stretch_3:
   _metadata:
@@ -447,8 +447,8 @@ hello_robot_stretch_3:
     evaluator: ''
     filename: stretch.xml
     model_name: stretch
-    notes: ''
-    verified: Unknown
+    notes: 'TODO: The lift actuator does not work properly in MuJoCo'
+    verified: 'No'
     verified_in_newton: Unknown
 i2rt_yam:
   _metadata:
@@ -465,7 +465,7 @@ i2rt_yam:
     filename: yam.xml
     model_name: yam
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 iit_softfoot:
   _metadata:
@@ -481,8 +481,8 @@ iit_softfoot:
     evaluator: ''
     filename: softfoot.xml
     model_name: softfoot
-    notes: ''
-    verified: Unknown
+    notes: 'scene.xml uses body/attach, causing issues with conversion. The model itself is slightly jittery in MuJoCo'
+    verified: 'No'
     verified_in_newton: Unknown
 kinova_gen3:
   _metadata:
@@ -499,7 +499,7 @@ kinova_gen3:
     filename: gen3.xml
     model_name: gen3
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 kuka_iiwa_14:
   _metadata:
@@ -516,7 +516,7 @@ kuka_iiwa_14:
     filename: iiwa14.xml
     model_name: iiwa14
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 leap_hand:
   _metadata:
@@ -533,7 +533,7 @@ leap_hand:
     filename: right_hand.xml
     model_name: right_hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: leap_hand
     description: 'Model variant: left_hand'
@@ -542,7 +542,7 @@ leap_hand:
     filename: left_hand.xml
     model_name: left_hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 low_cost_robot_arm:
   _metadata:
@@ -559,7 +559,7 @@ low_cost_robot_arm:
     filename: low_cost_robot_arm.xml
     model_name: low_cost_robot_arm
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 pal_talos:
   _metadata:
@@ -585,7 +585,7 @@ pal_talos:
     filename: talos_motor.xml
     model_name: talos_motor
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_talos
     description: 'Model variant: talos_position'
@@ -594,7 +594,7 @@ pal_talos:
     filename: talos_position.xml
     model_name: talos_position
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 pal_tiago:
   _metadata:
@@ -611,7 +611,7 @@ pal_tiago:
     filename: tiago_position.xml
     model_name: tiago_position
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_tiago
     description: 'Model variant: tiago'
@@ -629,7 +629,7 @@ pal_tiago:
     filename: tiago_velocity.xml
     model_name: tiago_velocity
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_tiago
     description: 'Model variant: tiago_motor'
@@ -638,7 +638,7 @@ pal_tiago:
     filename: tiago_motor.xml
     model_name: tiago_motor
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 pal_tiago_dual:
   _metadata:
@@ -655,7 +655,7 @@ pal_tiago_dual:
     filename: tiago_dual_velocity.xml
     model_name: tiago_dual_velocity
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual'
@@ -673,7 +673,7 @@ pal_tiago_dual:
     filename: tiago_dual_motor.xml
     model_name: tiago_dual_motor
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual_position'
@@ -682,7 +682,7 @@ pal_tiago_dual:
     filename: tiago_dual_position.xml
     model_name: tiago_dual_position
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 pndbotics_adam_lite:
   _metadata:

--- a/tools/menagerie_annotations.yaml
+++ b/tools/menagerie_annotations.yaml
@@ -31,7 +31,7 @@ agilex_piper:
   xml_files:
   - asset: agilex_piper
     description: 'Model variant: piper'
-    evaluation_date: '2026/10/03'
+    evaluation_date: '2025/10/03'
     evaluator: 'andrewkaufman'
     filename: piper.xml
     model_name: piper
@@ -48,12 +48,12 @@ agility_cassie:
   xml_files:
   - asset: agility_cassie
     description: 'Model variant: cassie'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: cassie.xml
     model_name: cassie
-    notes: ''
-    verified: Unknown
+    notes: 'One of the legs on the USD model has inverted triangles, but it seems to behave similarly to the original model'
+    verified: 'Yes'
     verified_in_newton: Unknown
 aloha:
   _metadata:
@@ -65,8 +65,8 @@ aloha:
   xml_files:
   - asset: aloha
     description: 'Model variant: aloha'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: aloha.xml
     model_name: aloha
     notes: ''
@@ -82,8 +82,8 @@ anybotics_anymal_b:
   xml_files:
   - asset: anybotics_anymal_b
     description: 'Model variant: anymal_b'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: anymal_b.xml
     model_name: anymal_b
     notes: ''
@@ -142,8 +142,8 @@ arx_l5:
   xml_files:
   - asset: arx_l5
     description: 'Model variant: arx_l5'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: arx_l5.xml
     model_name: arx_l5
     notes: ''
@@ -159,8 +159,8 @@ berkeley_humanoid:
   xml_files:
   - asset: berkeley_humanoid
     description: 'Model variant: berkeley_humanoid'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: berkeley_humanoid.xml
     model_name: berkeley_humanoid
     notes: ''
@@ -176,8 +176,8 @@ bitcraze_crazyflie_2:
   xml_files:
   - asset: bitcraze_crazyflie_2
     description: 'Model variant: cf2'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: cf2.xml
     model_name: cf2
     notes: ''
@@ -193,8 +193,8 @@ booster_t1:
   xml_files:
   - asset: booster_t1
     description: 'Model variant: t1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: t1.xml
     model_name: t1
     notes: ''
@@ -210,8 +210,8 @@ boston_dynamics_spot:
   xml_files:
   - asset: boston_dynamics_spot
     description: 'Model variant: spot'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: spot.xml
     model_name: spot
     notes: ''
@@ -219,8 +219,8 @@ boston_dynamics_spot:
     verified_in_newton: Unknown
   - asset: boston_dynamics_spot
     description: 'Model variant: spot_arm'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: spot_arm.xml
     model_name: spot_arm
     notes: ''
@@ -236,8 +236,8 @@ dynamixel_2r:
   xml_files:
   - asset: dynamixel_2r
     description: 'Model variant: dynamixel_2r'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: dynamixel_2r.xml
     model_name: dynamixel_2r
     notes: ''
@@ -270,8 +270,8 @@ fourier_n1:
   xml_files:
   - asset: fourier_n1
     description: 'Model variant: n1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: n1.xml
     model_name: n1
     notes: ''
@@ -287,8 +287,8 @@ franka_emika_panda:
   xml_files:
   - asset: franka_emika_panda
     description: 'Model variant: hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: hand.xml
     model_name: hand
     notes: ''
@@ -296,8 +296,8 @@ franka_emika_panda:
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: panda_nohand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: panda_nohand.xml
     model_name: panda_nohand
     notes: ''
@@ -305,17 +305,17 @@ franka_emika_panda:
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: mjx_panda'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: mjx_panda.xml
     model_name: mjx_panda
-    notes: 'TODO: There are strange shapes in MuJoCo, but it behaves correctly'
+    notes: 'There are strange shapes in MuJoCo, but it behaves correctly'
     verified: 'Yes'
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: panda'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: panda.xml
     model_name: panda
     notes: ''
@@ -323,8 +323,8 @@ franka_emika_panda:
     verified_in_newton: Unknown
   - asset: franka_emika_panda
     description: 'Model variant: mjx_panda_nohand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: mjx_panda_nohand.xml
     model_name: mjx_panda_nohand
     notes: ''
@@ -357,8 +357,8 @@ google_barkour_v0:
   xml_files:
   - asset: google_barkour_v0
     description: 'Model variant: barkour_v0_mjx'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: barkour_v0_mjx.xml
     model_name: barkour_v0_mjx
     notes: ''
@@ -383,8 +383,8 @@ google_barkour_vb:
   xml_files:
   - asset: google_barkour_vb
     description: 'Model variant: barkour_vb'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: barkour_vb.xml
     model_name: barkour_vb
     notes: ''
@@ -392,8 +392,8 @@ google_barkour_vb:
     verified_in_newton: Unknown
   - asset: google_barkour_vb
     description: 'Model variant: barkour_vb_mjx'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: barkour_vb_mjx.xml
     model_name: barkour_vb_mjx
     notes: ''
@@ -409,11 +409,11 @@ google_robot:
   xml_files:
   - asset: google_robot
     description: 'Model variant: robot'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: robot.xml
     model_name: robot
-    notes: 'TODO: It behaves similarly in MuJoCo, but the joints are not exactly the same'
+    notes: 'It behaves similarly in MuJoCo Simulate, but the joints are not exactly the same'
     verified: 'Yes'
     verified_in_newton: Unknown
 hello_robot_stretch:
@@ -430,7 +430,7 @@ hello_robot_stretch:
     evaluator: ''
     filename: stretch.xml
     model_name: stretch
-    notes: 'TODO: The lift actuator doesn't work properly in MuJoCo'
+    notes: 'The lift actuator does not work properly in MuJoCo Simulate'
     verified: 'No'
     verified_in_newton: Unknown
 hello_robot_stretch_3:
@@ -447,7 +447,7 @@ hello_robot_stretch_3:
     evaluator: ''
     filename: stretch.xml
     model_name: stretch
-    notes: 'TODO: The lift actuator does not work properly in MuJoCo'
+    notes: 'The lift actuator does not work properly in MuJoCo Simulate'
     verified: 'No'
     verified_in_newton: Unknown
 i2rt_yam:
@@ -460,8 +460,8 @@ i2rt_yam:
   xml_files:
   - asset: i2rt_yam
     description: 'Model variant: yam'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: yam.xml
     model_name: yam
     notes: ''
@@ -494,8 +494,8 @@ kinova_gen3:
   xml_files:
   - asset: kinova_gen3
     description: 'Model variant: gen3'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: gen3.xml
     model_name: gen3
     notes: ''
@@ -511,8 +511,8 @@ kuka_iiwa_14:
   xml_files:
   - asset: kuka_iiwa_14
     description: 'Model variant: iiwa14'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: iiwa14.xml
     model_name: iiwa14
     notes: ''
@@ -528,8 +528,8 @@ leap_hand:
   xml_files:
   - asset: leap_hand
     description: 'Model variant: right_hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: right_hand.xml
     model_name: right_hand
     notes: ''
@@ -537,8 +537,8 @@ leap_hand:
     verified_in_newton: Unknown
   - asset: leap_hand
     description: 'Model variant: left_hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: left_hand.xml
     model_name: left_hand
     notes: ''
@@ -554,8 +554,8 @@ low_cost_robot_arm:
   xml_files:
   - asset: low_cost_robot_arm
     description: 'Model variant: low_cost_robot_arm'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: low_cost_robot_arm.xml
     model_name: low_cost_robot_arm
     notes: ''
@@ -580,8 +580,8 @@ pal_talos:
     verified_in_newton: Unknown
   - asset: pal_talos
     description: 'Model variant: talos_motor'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: talos_motor.xml
     model_name: talos_motor
     notes: ''
@@ -589,8 +589,8 @@ pal_talos:
     verified_in_newton: Unknown
   - asset: pal_talos
     description: 'Model variant: talos_position'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: talos_position.xml
     model_name: talos_position
     notes: ''
@@ -606,8 +606,8 @@ pal_tiago:
   xml_files:
   - asset: pal_tiago
     description: 'Model variant: tiago_position'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_position.xml
     model_name: tiago_position
     notes: ''
@@ -624,8 +624,8 @@ pal_tiago:
     verified_in_newton: Unknown
   - asset: pal_tiago
     description: 'Model variant: tiago_velocity'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_velocity.xml
     model_name: tiago_velocity
     notes: ''
@@ -633,8 +633,8 @@ pal_tiago:
     verified_in_newton: Unknown
   - asset: pal_tiago
     description: 'Model variant: tiago_motor'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_motor.xml
     model_name: tiago_motor
     notes: ''
@@ -650,8 +650,8 @@ pal_tiago_dual:
   xml_files:
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual_velocity'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_dual_velocity.xml
     model_name: tiago_dual_velocity
     notes: ''
@@ -668,8 +668,8 @@ pal_tiago_dual:
     verified_in_newton: Unknown
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual_motor'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_dual_motor.xml
     model_name: tiago_dual_motor
     notes: ''
@@ -677,8 +677,8 @@ pal_tiago_dual:
     verified_in_newton: Unknown
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual_position'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_dual_position.xml
     model_name: tiago_dual_position
     notes: ''
@@ -698,7 +698,7 @@ pndbotics_adam_lite:
     evaluator: ''
     filename: adam_lite.xml
     model_name: adam_lite
-    notes: ''
+    notes: 'We do not apply the schema with inertia to visual geoms, so this model does not open in MuJoCo Simulate'
     verified: Unknown
     verified_in_newton: Unknown
 realsense_d435i:
@@ -711,12 +711,12 @@ realsense_d435i:
   xml_files:
   - asset: realsense_d435i
     description: 'Model variant: d435i'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: d435i.xml
     model_name: d435i
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 rethink_robotics_sawyer:
   _metadata:
@@ -728,12 +728,12 @@ rethink_robotics_sawyer:
   xml_files:
   - asset: rethink_robotics_sawyer
     description: 'Model variant: sawyer'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: sawyer.xml
     model_name: sawyer
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 robot_soccer_kit:
   _metadata:
@@ -745,12 +745,12 @@ robot_soccer_kit:
   xml_files:
   - asset: robot_soccer_kit
     description: 'Model variant: robot_soccer_kit'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: robot_soccer_kit.xml
     model_name: robot_soccer_kit
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 robotiq_2f85:
   _metadata:
@@ -762,12 +762,12 @@ robotiq_2f85:
   xml_files:
   - asset: robotiq_2f85
     description: 'Model variant: 2f85'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: 2f85.xml
     model_name: 2f85
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 robotiq_2f85_v4:
   _metadata:
@@ -792,7 +792,7 @@ robotiq_2f85_v4:
     evaluator: ''
     filename: mjx_2f85.xml
     model_name: mjx_2f85
-    notes: ''
+    notes: 'This converted model has extra collision geoms that interfere and do not allow the gripper to completely close in MuJoCo Simulate'
     verified: Unknown
     verified_in_newton: Unknown
 robotis_op3:
@@ -805,12 +805,12 @@ robotis_op3:
   xml_files:
   - asset: robotis_op3
     description: 'Model variant: op3'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: op3.xml
     model_name: op3
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 shadow_dexee:
   _metadata:
@@ -826,7 +826,7 @@ shadow_dexee:
     evaluator: ''
     filename: shadow_dexee.xml
     model_name: shadow_dexee
-    notes: ''
+    notes: 'The mujoco model itself will not load in MuJoCo Simulate: plugin mujoco.pid not found'
     verified: Unknown
     verified_in_newton: Unknown
 shadow_hand:
@@ -839,21 +839,21 @@ shadow_hand:
   xml_files:
   - asset: shadow_hand
     description: 'Model variant: right_hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: right_hand.xml
     model_name: right_hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: shadow_hand
     description: 'Model variant: left_hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: left_hand.xml
     model_name: left_hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 skydio_x2:
   _metadata:
@@ -865,12 +865,12 @@ skydio_x2:
   xml_files:
   - asset: skydio_x2
     description: 'Model variant: x2'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: x2.xml
     model_name: x2
-    notes: ''
-    verified: Unknown
+    notes: 'Collision on the rotor bodies not correct, possibly due to the ellipsoid geoms'
+    verified: 'Yes'
     verified_in_newton: Unknown
 stanford_tidybot:
   _metadata:
@@ -882,21 +882,21 @@ stanford_tidybot:
   xml_files:
   - asset: stanford_tidybot
     description: 'Model variant: tidybot'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tidybot.xml
     model_name: tidybot
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: stanford_tidybot
     description: 'Model variant: base'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: base.xml
     model_name: base
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 trossen_vx300s:
   _metadata:
@@ -908,12 +908,12 @@ trossen_vx300s:
   xml_files:
   - asset: trossen_vx300s
     description: 'Model variant: vx300s'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: vx300s.xml
     model_name: vx300s
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 trossen_wx250s:
   _metadata:
@@ -925,12 +925,12 @@ trossen_wx250s:
   xml_files:
   - asset: trossen_wx250s
     description: 'Model variant: wx250s'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: wx250s.xml
     model_name: wx250s
-    notes: ''
-    verified: Unknown
+    notes: 'The original model gripper does not work properly, the USD converted model behaves the same'
+    verified: 'Yes'
     verified_in_newton: Unknown
 trs_so_arm100:
   _metadata:
@@ -942,12 +942,12 @@ trs_so_arm100:
   xml_files:
   - asset: trs_so_arm100
     description: 'Model variant: so_arm100'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: so_arm100.xml
     model_name: so_arm100
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 ufactory_lite6:
   _metadata:
@@ -959,30 +959,30 @@ ufactory_lite6:
   xml_files:
   - asset: ufactory_lite6
     description: 'Model variant: lite6_gripper_wide'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: lite6_gripper_wide.xml
     model_name: lite6_gripper_wide
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: ufactory_lite6
     description: 'Model variant: lite6'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: lite6.xml
     model_name: lite6
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: ufactory_lite6
     description: 'Model variant: lite6_gripper_narrow'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: lite6_gripper_narrow.xml
     model_name: lite6_gripper_narrow
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 ufactory_xarm7:
   _metadata:
@@ -994,30 +994,30 @@ ufactory_xarm7:
   xml_files:
   - asset: ufactory_xarm7
     description: 'Model variant: hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: hand.xml
     model_name: hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: ufactory_xarm7
     description: 'Model variant: xarm7_nohand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: xarm7_nohand.xml
     model_name: xarm7_nohand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: ufactory_xarm7
     description: 'Model variant: xarm7'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: xarm7.xml
     model_name: xarm7
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 umi_gripper:
   _metadata:
@@ -1029,12 +1029,12 @@ umi_gripper:
   xml_files:
   - asset: umi_gripper
     description: 'Model variant: umi_gripper'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: umi_gripper.xml
     model_name: umi_gripper
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 unitree_a1:
   _metadata:
@@ -1046,12 +1046,12 @@ unitree_a1:
   xml_files:
   - asset: unitree_a1
     description: 'Model variant: a1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: a1.xml
     model_name: a1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 unitree_g1:
   _metadata:
@@ -1063,12 +1063,12 @@ unitree_g1:
   xml_files:
   - asset: unitree_g1
     description: 'Model variant: g1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: g1.xml
     model_name: g1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: unitree_g1
     description: 'Model variant: g1_mjx'
@@ -1076,17 +1076,17 @@ unitree_g1:
     evaluator: ''
     filename: g1_mjx.xml
     model_name: g1_mjx
-    notes: ''
+    notes: 'Some of the collision volumes are visible in green in MuJoCo Simulate'
     verified: Unknown
     verified_in_newton: Unknown
   - asset: unitree_g1
     description: 'Model variant: g1_with_hands'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: g1_with_hands.xml
     model_name: g1_with_hands
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 unitree_go1:
   _metadata:
@@ -1098,12 +1098,12 @@ unitree_go1:
   xml_files:
   - asset: unitree_go1
     description: 'Model variant: go1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: go1.xml
     model_name: go1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 unitree_go2:
   _metadata:
@@ -1115,21 +1115,21 @@ unitree_go2:
   xml_files:
   - asset: unitree_go2
     description: 'Model variant: go2_mjx'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: go2_mjx.xml
     model_name: go2_mjx
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: unitree_go2
     description: 'Model variant: go2'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: go2.xml
     model_name: go2
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 unitree_h1:
   _metadata:
@@ -1141,12 +1141,12 @@ unitree_h1:
   xml_files:
   - asset: unitree_h1
     description: 'Model variant: h1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: h1.xml
     model_name: h1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 unitree_z1:
   _metadata:
@@ -1158,21 +1158,21 @@ unitree_z1:
   xml_files:
   - asset: unitree_z1
     description: 'Model variant: z1'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: z1.xml
     model_name: z1
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: unitree_z1
     description: 'Model variant: z1_gripper'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: z1_gripper.xml
     model_name: z1_gripper
-    notes: ''
-    verified: Unknown
+    notes: 'Note that the original model gripper shakes in MuJoCo Simulate, the USD model behaves the same'
+    verified: 'Yes'
     verified_in_newton: Unknown
 universal_robots_ur10e:
   _metadata:
@@ -1184,12 +1184,12 @@ universal_robots_ur10e:
   xml_files:
   - asset: universal_robots_ur10e
     description: 'Model variant: ur10e'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: ur10e.xml
     model_name: ur10e
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 universal_robots_ur5e:
   _metadata:
@@ -1201,12 +1201,12 @@ universal_robots_ur5e:
   xml_files:
   - asset: universal_robots_ur5e
     description: 'Model variant: ur5e'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: ur5e.xml
     model_name: ur5e
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 wonik_allegro:
   _metadata:
@@ -1218,19 +1218,19 @@ wonik_allegro:
   xml_files:
   - asset: wonik_allegro
     description: 'Model variant: right_hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: right_hand.xml
     model_name: right_hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: wonik_allegro
     description: 'Model variant: left_hand'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: left_hand.xml
     model_name: left_hand
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown

--- a/tools/menagerie_annotations.yaml
+++ b/tools/menagerie_annotations.yaml
@@ -413,8 +413,8 @@ google_robot:
     evaluator: 'LouRohanNV'
     filename: robot.xml
     model_name: robot
-    notes: 'It behaves similarly in MuJoCo Simulate, but the joints are not exactly the same'
-    verified: 'Yes'
+    notes: 'The shoulder actuator from the USD model is weaker in MuJoCo Simulate, possibly due to how the position-based actuators decoded to general actuators'
+    verified: 'No'
     verified_in_newton: Unknown
 hello_robot_stretch:
   _metadata:
@@ -792,7 +792,7 @@ robotiq_2f85_v4:
     evaluator: ''
     filename: mjx_2f85.xml
     model_name: mjx_2f85
-    notes: 'This converted model has extra collision geoms that interfere and do not allow the gripper to completely close in MuJoCo Simulate'
+    notes: 'This converted model has collision geoms that interfere and do not allow the gripper to completely close in MuJoCo Simulate, collision is somehow disabled for the MJCF model between the left and right follower bodies and the base, possibly due to different conaffinity values'
     verified: Unknown
     verified_in_newton: Unknown
 robotis_op3:
@@ -1072,8 +1072,8 @@ unitree_g1:
     verified_in_newton: Unknown
   - asset: unitree_g1
     description: 'Model variant: g1_mjx'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: g1_mjx.xml
     model_name: g1_mjx
     notes: 'Some of the collision volumes are visible in green in MuJoCo Simulate'

--- a/tools/menagerie_annotations.yaml
+++ b/tools/menagerie_annotations.yaml
@@ -309,7 +309,7 @@ franka_emika_panda:
     evaluator: 'LouRohanNV'
     filename: mjx_panda.xml
     model_name: mjx_panda
-    notes: 'There are strange shapes in MuJoCo, but it behaves correctly'
+    notes: 'The group 3 collision shapes are visible in MuJoCo Simulate, but it behaves correctly'
     verified: 'Yes'
     verified_in_newton: Unknown
   - asset: franka_emika_panda
@@ -792,8 +792,8 @@ robotiq_2f85_v4:
     evaluator: ''
     filename: mjx_2f85.xml
     model_name: mjx_2f85
-    notes: 'This converted model has collision geoms that interfere and do not allow the gripper to completely close in MuJoCo Simulate, collision is somehow disabled for the MJCF model between the left and right follower bodies and the base, possibly due to different conaffinity values'
-    verified: Unknown
+    notes: 'The left and right follower bodies collide with the base due to unsupported collision filtering via the `contype` & `conaffinity` in the MJCF model'
+    verified: 'No'
     verified_in_newton: Unknown
 robotis_op3:
   _metadata:

--- a/tools/menagerie_annotations.yaml
+++ b/tools/menagerie_annotations.yaml
@@ -108,12 +108,12 @@ anybotics_anymal_c:
     verified_in_newton: Unknown
   - asset: anybotics_anymal_c
     description: 'Model variant: anymal_c_mjx'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: anymal_c_mjx.xml
     model_name: anymal_c_mjx
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
 apptronik_apollo:
   _metadata:
@@ -253,12 +253,12 @@ flybody:
   xml_files:
   - asset: flybody
     description: 'Model variant: fruitfly'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: fruitfly.xml
     model_name: fruitfly
-    notes: ''
-    verified: Unknown
+    notes: 'Many of the actuators in the USD model are not working properly in MuJoCo Simulate'
+    verified: 'No'
     verified_in_newton: Unknown
 fourier_n1:
   _metadata:
@@ -571,12 +571,12 @@ pal_talos:
   xml_files:
   - asset: pal_talos
     description: 'Model variant: talos'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: talos.xml
     model_name: talos
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_talos
     description: 'Model variant: talos_motor'
@@ -615,12 +615,12 @@ pal_tiago:
     verified_in_newton: Unknown
   - asset: pal_tiago
     description: 'Model variant: tiago'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago.xml
     model_name: tiago
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_tiago
     description: 'Model variant: tiago_velocity'
@@ -659,12 +659,12 @@ pal_tiago_dual:
     verified_in_newton: Unknown
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: tiago_dual.xml
     model_name: tiago_dual
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: pal_tiago_dual
     description: 'Model variant: tiago_dual_motor'
@@ -698,7 +698,7 @@ pndbotics_adam_lite:
     evaluator: ''
     filename: adam_lite.xml
     model_name: adam_lite
-    notes: 'We do not apply the schema with inertia to visual geoms, so this model does not open in MuJoCo Simulate'
+    notes: 'We do not apply the schema with inertia to visual geoms, thus the model does not open in MuJoCo Simulate'
     verified: Unknown
     verified_in_newton: Unknown
 realsense_d435i:
@@ -779,12 +779,12 @@ robotiq_2f85_v4:
   xml_files:
   - asset: robotiq_2f85_v4
     description: 'Model variant: 2f85'
-    evaluation_date: ''
-    evaluator: ''
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: 2f85.xml
     model_name: 2f85
     notes: ''
-    verified: Unknown
+    verified: 'Yes'
     verified_in_newton: Unknown
   - asset: robotiq_2f85_v4
     description: 'Model variant: mjx_2f85'

--- a/tools/menagerie_annotations.yaml
+++ b/tools/menagerie_annotations.yaml
@@ -31,8 +31,8 @@ agilex_piper:
   xml_files:
   - asset: agilex_piper
     description: 'Model variant: piper'
-    evaluation_date: '2025/10/03'
-    evaluator: 'andrewkaufman'
+    evaluation_date: '2026/03/06'
+    evaluator: 'LouRohanNV'
     filename: piper.xml
     model_name: piper
     notes: ''


### PR DESCRIPTION
## Description
I ran the benchmark script then went through each unverified model and looked at how similar it behaved in MuJoCo Simulate to the MJCF model. Many models require a scene for testing, so I converted the scene MJCF files manually before testing in Simulate. There are a few that are still `verified: 'Unknown'` because I just didn't know what to do with them, maybe they should be `'No'`, or maybe not. This process was pretty tedious, I'll be staring at the diffs again to be sure that I got things right.

Regarding scenes:
- We should have a mode of the benchmark script that automatically converts the scenes
- Some of the "pal" models have different versions (motor, position, etc.) and I had to make new scene files to add the scenes

Verification:
- Sometimes a model's appearance was slightly off and I still marked it as verified (possibly due to spec issues, or something else)
- All I can do typically is wiggle some of the actuators and look at the default behavior of the models in the scene, I can't tell if all of the attributes for every element round-tripped perfectly. It would be great if we could prove that these round-tripped robots are actually simulation-ready.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).

<img width="400" height="416" alt="image" src="https://github.com/user-attachments/assets/471796a3-67d8-4048-a660-9a82ea14efbe" />
