### PR TITLE
Update to mujoco 3.8

### DIFF
--- a/mujoco_usd_converter/_impl/joint.py
+++ b/mujoco_usd_converter/_impl/joint.py
@@ -79,7 +79,7 @@ def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint):
     set_schema_attribute(prim, "mjc:actuatorfrcrange:max", joint.actfrcrange[1])
     set_schema_attribute(prim, "mjc:actuatorgravcomp", bool(joint.actgravcomp))
     set_schema_attribute(prim, "mjc:armature", joint.armature)
-    set_schema_attribute(prim, "mjc:damping", joint.damping)
+    set_schema_attribute(prim, "mjc:damping", joint.damping[0])
     set_schema_attribute(prim, "mjc:frictionloss", joint.frictionloss)
     set_schema_attribute(prim, "mjc:group", joint.group)
     set_schema_attribute(prim, "mjc:margin", joint.margin)
@@ -90,7 +90,7 @@ def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint):
     set_schema_attribute(prim, "mjc:solreflimit", list(joint.solref_limit))
     set_schema_attribute(prim, "mjc:springdamper", list(joint.springdamper))
     set_schema_attribute(prim, "mjc:springref", joint.springref)
-    set_schema_attribute(prim, "mjc:stiffness", joint.stiffness)
+    set_schema_attribute(prim, "mjc:stiffness", joint.stiffness[0])
 
 
 def is_limited(joint: mujoco.MjsJoint, data: ConversionData) -> bool:

--- a/mujoco_usd_converter/_impl/scene.py
+++ b/mujoco_usd_converter/_impl/scene.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import usdex.core
-from pxr import Gf, Usd, UsdPhysics, Vt
+from pxr import Gf, Tf, Usd, UsdPhysics, Vt
 
 from .data import ConversionData, Tokens
 from .numpy import convert_vec3d
@@ -67,7 +67,16 @@ def convert_scene(data: ConversionData):
     set_schema_attribute(scene_prim, "mjc:flag:energy", is_enabled(1 << 1, data))
     set_schema_attribute(scene_prim, "mjc:flag:fwdinv", is_enabled(1 << 2, data))
     set_schema_attribute(scene_prim, "mjc:flag:invdiscrete", is_enabled(1 << 3, data))
-    set_schema_attribute(scene_prim, "mjc:flag:multiccd", is_enabled(1 << 4, data))
+
+    # multiccd should be enabled by default, but the schema was not changed to reflect this
+    # We set it to the data spec value regardless of the schema default
+    # If the default schema value is ever changed to enable multiccd, remove the workaround and use set_schema_attribute
+    attr = scene_prim.GetAttribute("mjc:flag:multiccd")
+    default = attr.Get()
+    if default:
+        Tf.Warn("mjc:flag:multiccd default value is fixed, revert the workaround for the incorrect schema default")
+    attr.Set(is_enabled(1 << 4, data))
+
     set_schema_attribute(scene_prim, "mjc:flag:override", is_enabled(1 << 0, data))
 
     actuator_groups = [i for i in range(31) if data.spec.option.disableactuator & (1 << i)]

--- a/mujoco_usd_converter/_impl/tendon.py
+++ b/mujoco_usd_converter/_impl/tendon.py
@@ -36,9 +36,9 @@ def convert_tendon(parent: Usd.Prim, name: str, tendon: mujoco.MjsTendon, data: 
     tendon_prim: Usd.Prim = parent.GetStage().DefinePrim(parent.GetPath().AppendChild(name))
     tendon_prim.SetTypeName("MjcTendon")
 
-    set_schema_attribute(tendon_prim, "mjc:stiffness", tendon.stiffness)
+    set_schema_attribute(tendon_prim, "mjc:stiffness", tendon.stiffness[0])
     set_schema_attribute(tendon_prim, "mjc:springlength", Vt.DoubleArray(tendon.springlength))
-    set_schema_attribute(tendon_prim, "mjc:damping", tendon.damping)
+    set_schema_attribute(tendon_prim, "mjc:damping", tendon.damping[0])
     set_schema_attribute(tendon_prim, "mjc:frictionloss", tendon.frictionloss)
     set_schema_attribute(tendon_prim, "mjc:solreffriction", Vt.DoubleArray(tendon.solref_friction))
     set_schema_attribute(tendon_prim, "mjc:solimpfriction", Vt.DoubleArray(tendon.solimp_friction))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mujoco>=3.6.0",
+    "mujoco>=3.8.0",
     "usd-exchange>=2.2.2", # locked to USD 25.05
     "newton-usd-schemas>=0.1.0",
     "numpy-stl>=3.2",

--- a/tests/data/scene_attributes.xml
+++ b/tests/data/scene_attributes.xml
@@ -31,7 +31,7 @@
           eulerdamp="disable" autoreset="disable"
           nativeccd="disable" island="disable"
           energy="enable" fwdinv="enable"
-          invdiscrete="enable" multiccd="enable"
+          invdiscrete="enable" multiccd="disable"
           override="enable"/>
   </option>
 

--- a/tests/testScene.py
+++ b/tests/testScene.py
@@ -64,6 +64,7 @@ class TestScene(ConverterTestCase):
             "mjc:flag:island",
             "mjc:flag:limit",
             "mjc:flag:midphase",
+            "mjc:flag:multiccd",
             "mjc:flag:nativeccd",
             "mjc:flag:refsafe",
             "mjc:flag:sensor",
@@ -80,7 +81,6 @@ class TestScene(ConverterTestCase):
             "mjc:flag:energy",
             "mjc:flag:fwdinv",
             "mjc:flag:invdiscrete",
-            "mjc:flag:multiccd",
             "mjc:flag:override",
         ]
 
@@ -158,8 +158,15 @@ class TestScene(ConverterTestCase):
         self.assertAlmostEqual(physics_scene.GetGravityMagnitudeAttr().Get(), 9.81, 5)
 
         # Check that only MJC properties without a default value are authored
+        # Some properties are overridden by the converter to match the data spec (remove this when the schema is updated)
+        overridden_properties = [
+            "mjc:flag:multiccd",
+        ]
         for property in scene.GetPropertiesInNamespace("mjc"):
-            self.assertFalse(property.HasAuthoredValue(), f"Property {property.GetName()} should not be authored")
+            if property.GetName() in overridden_properties:
+                self.assertTrue(property.HasAuthoredValue(), f"Property {property.GetName()} should be authored")
+            else:
+                self.assertFalse(property.HasAuthoredValue(), f"Property {property.GetName()} should not be authored")
 
         # Test that default values are not authored but still available via schema defaults
         # Most flag attributes should not be authored since they match schema defaults
@@ -178,6 +185,7 @@ class TestScene(ConverterTestCase):
             "mjc:flag:island",
             "mjc:flag:limit",
             "mjc:flag:midphase",
+            "mjc:flag:multiccd",
             "mjc:flag:nativeccd",
             "mjc:flag:refsafe",
             "mjc:flag:sensor",
@@ -187,13 +195,14 @@ class TestScene(ConverterTestCase):
 
         for attr_name in default_enabled_flags:
             attr: Usd.Attribute = scene.GetAttribute(attr_name)
-            self.assertEqual(attr.Get(), True, f"Default attribute {attr_name} should still return True via schema default")
+            # Some properties are overridden by the converter to match the data spec (remove this when the schema is updated)
+            if attr_name not in overridden_properties:
+                self.assertEqual(attr.Get(), True, f"Default attribute {attr_name} should still return True via schema default")
 
         default_disabled_flags = [
             "mjc:flag:energy",
             "mjc:flag:fwdinv",
             "mjc:flag:invdiscrete",
-            "mjc:flag:multiccd",
             "mjc:flag:override",
         ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.6.0"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -303,23 +303,23 @@ dependencies = [
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/82/f8f08dfe9123df4351b560f894f0e7166c1a45a0dd2f04145ed00b8f849b/mujoco-3.6.0.tar.gz", hash = "sha256:15c89f423e33bce0860ad7061763b72323426d6348d7b2e46ebdcc37b11e0905", size = 915041, upload-time = "2026-03-11T01:45:42.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/d8/9aae1a021b6e15ee69d805d893e01dda71cbaae1c75d5f8ec8e12916cb7c/mujoco-3.8.0.tar.gz", hash = "sha256:250afe57458d6881b2d7659fa0029a128cb57cbbb620268d95647fb9ad742183", size = 918250, upload-time = "2026-04-24T22:59:07.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/afb86dfbe53ff4aec0eb265713255899db9947539cd3f235450d82b669f7/mujoco-3.6.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:8f4d3d2e08472647550f2167a7c72b75e7a749cd9ce62820582d47518b3cabf9", size = 7145685, upload-time = "2026-03-11T01:44:46.596Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/6a/b1b3446f3b99bdbc56b4b63dadf4c5cd47ae08e3bf110f36dc5d3fde7836/mujoco-3.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:69dec85b1a4eeba1be9b6c986dbe6651e993c413a93f072213b175b7d7e19afd", size = 7143715, upload-time = "2026-03-11T01:44:50.471Z" },
-    { url = "https://files.pythonhosted.org/packages/86/36/87b908879a070f9f78d9d27b739ac18cb5b8337762ba9e88183ccfa582e1/mujoco-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0a0450e94cbf4b176936471279cb995567fba5ca5b85d6f71eaee920cd94627", size = 6940688, upload-time = "2026-03-11T01:44:53.532Z" },
-    { url = "https://files.pythonhosted.org/packages/94/27/043852c6d46b9f5b092430e334b2102753f2b63b262f4f466c75c0b9daac/mujoco-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44b923861cade57044d21cb30f8da78460208cc3f3870f58d83651af35c5f063", size = 7383476, upload-time = "2026-03-11T01:44:56.952Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/15/ae5df3d9b8fde39f7d75d5143bd9d0a74c1b189b385248667c072136cdea/mujoco-3.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:3ebaa0f71de1aa3aca4c47990f9b29d65f9829d7dbbaeb05c1a23a9fce176c47", size = 5665428, upload-time = "2026-03-11T01:44:59.854Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/75/d8afb4e98b58a119be3cba8da88b75cf53ff16f83baa9a14d37aa15a426e/mujoco-3.6.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:5ae08e9249dc04b9da2bb22fe1657277996ad96632f3835cdf3ad60e47beda68", size = 7158583, upload-time = "2026-03-11T01:45:03.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/fb/5335c0ba2e88f4b8f8300c15966823dbb96ecc906a61c86bcf9cdac77311/mujoco-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5f1a57423e49e6a35ba9cc8335fe023973c11fc29569fee60e14725b384d557d", size = 7155716, upload-time = "2026-03-11T01:45:06.113Z" },
-    { url = "https://files.pythonhosted.org/packages/00/15/e3f01cee200438baab9db1de79bfd67e3a3f2ab1b02c48268e094815339f/mujoco-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af6d762148b33fc96bf21125d0198048f5d6f2c911da75e0c164a9e7188f8e38", size = 6954046, upload-time = "2026-03-11T01:45:09.133Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a2/93ce08c5fcbe04dd997fe207bdc008e856b664ecf69db6442035aacf7fba/mujoco-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6708a62f4c85bef51c47d0835d29e116da96b4f6a4cf5beef3467dca8af8c407", size = 7398612, upload-time = "2026-03-11T01:45:11.716Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/a5/a84a9edc6234a2ee29a6b008d432e1c3855795f10a51786ee2260128ed12/mujoco-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:99c4b2ec48e988d7ab2dce38e65f237c326954c06323cdd405718034da0b2077", size = 5689948, upload-time = "2026-03-11T01:45:14.304Z" },
-    { url = "https://files.pythonhosted.org/packages/38/c4/f8959e3d5d98b282e081ce08d07cd71ae949cc0ad9f2c39c0a69fcb88c8c/mujoco-3.6.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:e7e60ee4c07f6fecd63c23e6f47b8d7cdacad75d311739d50d50b5107a630af2", size = 7159624, upload-time = "2026-03-11T01:45:16.893Z" },
-    { url = "https://files.pythonhosted.org/packages/26/55/7407eced2c44fbea233302d2c11e778852ea0f2eb0e14610f13a7e0d6ac7/mujoco-3.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ea71750f8cbe24b02a091093592f08fb71c95692b43c25e87dabe496ace0bb55", size = 7093719, upload-time = "2026-03-11T01:45:19.191Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/cc/2aae89c3a83fed29ccb9057c05fb4a218b2a42c6dea136d9a78fea6b39f8/mujoco-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:094de585a2084508f1cfd76170b0dfe1d9c122b3bd4677e96ef2383100c9032f", size = 6982824, upload-time = "2026-03-11T01:45:22.078Z" },
-    { url = "https://files.pythonhosted.org/packages/52/6c/5ec4e93676a65064a6591176772e00cfa02716156a1d0a7d646a8203348f/mujoco-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8714fab312c7ee58f45bda7ef8762da2184e3a6a1d780a5093e93a160d66bd3d", size = 7473873, upload-time = "2026-03-11T01:45:24.671Z" },
-    { url = "https://files.pythonhosted.org/packages/92/22/38d82f0c34213af53afbbb248b3442943ef48ffbac1e4c909b321e02ac56/mujoco-3.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:3d4ec53e4e20fcc85843d607fa1648e0b12d2d2de81ee6f85926e95a7e84e8d8", size = 5764289, upload-time = "2026-03-11T01:45:27.014Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c0/250652d6ad5bb166d7ce519aad4f8d37b97f75562eb02d2f58afb48447ba/mujoco-3.8.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:e6c7978eb2719b3db3c0ee674feb6d41fb5482f5491fb66e01762f1e7bea4750", size = 7222479, upload-time = "2026-04-24T22:58:12.399Z" },
+    { url = "https://files.pythonhosted.org/packages/99/d8/fb5b7829be742084352942de7ad87751e790587626a7f0767c30a575d63c/mujoco-3.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:956aaaaa78d9402154eaba89a277d1c227bd532811b1eb42b0810573f263e65e", size = 7244062, upload-time = "2026-04-24T22:58:15.245Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/a4ca7260159136c0032ee2588ad25175ac156faf4a8cd3a0c66ca886465e/mujoco-3.8.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa2a499277150a562c60e658a97ec1e8e8828b5075fdbe43745835d87e98b62e", size = 6691365, upload-time = "2026-04-24T22:58:17.055Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/09/d06b7a352dd70b3d7c46781082b9ff485b65085d88caefa0bb0df1d4f0d9/mujoco-3.8.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8b5981d94efd6d99bc8eac7eb322c50d680f306f5e89a260b6d874992ffa7c", size = 7131040, upload-time = "2026-04-24T22:58:19.262Z" },
+    { url = "https://files.pythonhosted.org/packages/11/bc/cd52b2426a030db5bd8ef77d3482ab0a2f0b5c0350cd992f575cc0d4eaba/mujoco-3.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:58f5c499abcf81eb3ab3d5e40dd98b2cc7433e032b81460279f808e517099cf2", size = 5714596, upload-time = "2026-04-24T22:58:21.53Z" },
+    { url = "https://files.pythonhosted.org/packages/83/46/e68d7a05c0c8367e38f5925fc85553df735c379dfbfe0c8adee4833e610b/mujoco-3.8.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:c3579cdbeb2bd157be43e13272953e941acdc59f4a74495a567fa4bc2b4f0166", size = 7235564, upload-time = "2026-04-24T22:58:24.097Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ae/aeda34f9e07b295be5757ffa006218be341f193138db1e6ee0e7f88a245e/mujoco-3.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d400c0489d8b958eaba361af84d0315a642215e5236485a23460b9636d665730", size = 7255745, upload-time = "2026-04-24T22:58:26.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ae/89c113e77e25e4a5e76c9856c51229ea75d790ffc65f10f0aec794b2e4fe/mujoco-3.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d4297fbd8bce087b52c47c4a4ef4a8e49e9e27db8e419f048c25ebe8d4ba0cb", size = 6705135, upload-time = "2026-04-24T22:58:27.735Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1f/046931077b28e62a5540f8a942c77fec323b7d5e713d3831d0d55edbe08f/mujoco-3.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c764f37204219506ff0ed7acf7cc3848c65dcf39438cefbe26056b3fd649cd8", size = 7145390, upload-time = "2026-04-24T22:58:29.756Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b4/fbe055a11cc98542a3f0c78051247ae2b34d0ed468cf85feb2c21b7ecde2/mujoco-3.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4521c322a1d1b4925610246548af42031c04ba0ca73956be0fb9fd0465aaa4", size = 5739709, upload-time = "2026-04-24T22:58:31.805Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/35aad24bef1f36e9ebf63367938b16abec82407338d612c37624ff20b0e3/mujoco-3.8.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:a495da0cd01aff6ac94ec97f0a1d913e1afe071daf107e220f81814435227982", size = 7265096, upload-time = "2026-04-24T22:58:33.475Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d7/2ee5a123431eb50f234de2759e46f3d0c02876e0b1ffce1b26102ed388e7/mujoco-3.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cc1d25b0cd47248fd39681310950b2bea0f6098f57358c0c02730d365bb80ba1", size = 7204862, upload-time = "2026-04-24T22:58:35.978Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/62/a488e6e0963e0210b8262650d25e51c4c597ff7beed4fe01a7e88e3abfc5/mujoco-3.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:980ab5a2210777cf766e53eb574726f9360e2a87e47d83a6c8d801fb71f2fe52", size = 6743542, upload-time = "2026-04-24T22:58:38.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bc2271210dad5c6ab73af294779226308e9cf4ed8bc2dbe59922eb8702ed/mujoco-3.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:323fedd14905b73cfe56ea8ff916716ccf8b57cff348a7aa6932c8983a465d64", size = 7226045, upload-time = "2026-04-24T22:58:41.117Z" },
+    { url = "https://files.pythonhosted.org/packages/65/87/198a88747ff0c01e35070c0c80ae0c05ff8d1a61d6e6f379a4e5ff3e6185/mujoco-3.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:8db22dbc5a6c98241549c8161f20a2b0c2ccc5d08fa42595e7a4b594e35a70dd", size = 5813167, upload-time = "2026-04-24T22:58:43.469Z" },
 ]
 
 [[package]]
@@ -347,7 +347,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mujoco", specifier = ">=3.6.0" },
+    { name = "mujoco", specifier = ">=3.8.0" },
     { name = "newton-usd-schemas", specifier = ">=0.1.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },


### PR DESCRIPTION
- The scene's `multiccd` schema property should be enabled by default, but it wasn't updated, so workaround this by force-overriding it during conversion and in testing scene schema defaults
- Stiffness in joints and tendons and damping in joints and tendons now support nonlinear polynomial force profiles, the schema still only contains the linear coefficients.

## Description
<!-- Set a descriptive pull request title. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues relevant to this PR. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
