### PR TITLE
Author body-level mass/inertia for multi-collider inferred-inertial bodies (fixes #100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Aligned converter output with MuJoCo 3.10 USD decoder expectations
 - Bodies with fixed child bodies are now considered articulation roots
+- Bodies with an inferred inertial from multiple mass-contributing geoms now author the compiled body-level mass properties, so downstream readers reproduce MuJoCo's body mass exactly (#100)
 
 ## Dependencies
 

--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -4,10 +4,10 @@
 import mujoco
 import numpy as np
 import usdex.core
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, Vt
+from pxr import Gf, Sdf, Tf, Usd, UsdGeom, UsdPhysics, Vt
 
 from .data import ConversionData, Tokens
-from .geom import convert_geom, get_geom_name
+from .geom import convert_geom, get_geom_name, is_physics_geom
 from .joint import convert_joints
 from .numpy import convert_quatf, convert_vec3d
 from .utils import set_schema_attribute, set_transform
@@ -79,22 +79,25 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
                 if not np.isnan(body.fullinertia[0]):
                     body_over.ApplyAPI("NewtonMassAPI")
                     set_schema_attribute(body_over, "newton:inertia", Vt.DoubleArray.FromNumpy(body.fullinertia))
-        else:
-            # Author body-level mass/inertia from the compiled model so downstream
-            # readers honor it authoritatively. Without this, a rigid body with
-            # multiple collision shapes can have its mass recomputed from geometry
-            # (e.g. the Newton USD import), diverging from MuJoCo's body inertia.
-            if data.model is None:
-                data.model = data.spec.compile()
-            bid = data.model.body(body.name).id
-            bmass = float(data.model.body_mass[bid])
-            if bmass > 0.0:
+        elif sum(is_physics_geom(x, data) for x in body.geoms) > 1:
+            # When the inferred inertial comes from a body with several collider shapes,
+            # downstream readers may combine them differently than MuJoCo does (e.g.
+            # Newton's USD import recomputes multi-shape bodies from geometry, ignoring
+            # per-geom authored mass, and massless density="0" geoms author no mass
+            # properties at all). Author the compiled body-level mass properties so the
+            # USD unambiguously reproduces MuJoCo's inferred inertial. Single-shape
+            # bodies are already represented faithfully by the geom-level properties,
+            # so we leave them free to be recomputed from geometry.
+            body_id = get_model_body_id(body, data)
+            mass = float(data.model.body_mass[body_id]) if body_id is not None else 0.0
+            if mass > 0.0:
                 mass_api: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(body_over)
-                mass_api.CreateMassAttr().Set(bmass)
-                mass_api.CreateCenterOfMassAttr().Set(convert_vec3d(data.model.body_ipos[bid]))
-                inertia = convert_vec3d(data.model.body_inertia[bid])
+                mass_api.CreateMassAttr().Set(mass)
+                mass_api.CreateCenterOfMassAttr().Set(convert_vec3d(data.model.body_ipos[body_id]))
+                inertia = convert_vec3d(data.model.body_inertia[body_id])
+                # If the inertia is zero, don't set the principal axes or diagonal inertia (see above)
                 if inertia != Gf.Vec3f(0, 0, 0):
-                    mass_api.CreatePrincipalAxesAttr().Set(convert_quatf(data.model.body_iquat[bid]).GetNormalized())
+                    mass_api.CreatePrincipalAxesAttr().Set(convert_quatf(data.model.body_iquat[body_id]).GetNormalized())
                     mass_api.CreateDiagonalInertiaAttr().Set(inertia)
 
         convert_joints(parent=body_over, body=body, data=data)
@@ -109,6 +112,41 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
             set_schema_attribute(child_body_over, "newton:jointsAddMobility", True)
 
     return body_prim
+
+
+def iter_bodies(body: mujoco.MjsBody):
+    yield body
+    for child_body in body.bodies:
+        yield from iter_bodies(child_body)
+
+
+def get_model_body_id(body: mujoco.MjsBody, data: ConversionData) -> int | None:
+    if data.model_unavailable:
+        return None
+
+    if data.model is None:
+        # compiling can mutate or even invalidate live spec elements (e.g. fusestatic
+        # removes fused bodies, discardvisual removes geoms), so the model is always
+        # compiled from a copy. A model that MuJoCo cannot compile has no inferred
+        # inertial to author, but it may still be convertible, so continue without it.
+        try:
+            data.model = data.spec.copy().compile()
+        except Exception as e:
+            data.model_unavailable = True
+            Tf.Warn(f"Body-level mass properties will not be authored. Failed to compile model: {e}")
+            return None
+
+    # model body ids follow the spec's depth-first document order, which is the only
+    # reliable lookup for unnamed bodies. A count mismatch means compilation
+    # restructured the body tree (e.g. fusestatic), so the compiled body data
+    # cannot be transferred onto the converted bodies.
+    spec_bodies = list(iter_bodies(data.spec.worldbody))
+    if len(spec_bodies) != data.model.nbody:
+        data.model_unavailable = True
+        Tf.Warn("Body-level mass properties will not be authored. Compilation restructured the body tree (e.g. fusestatic).")
+        return None
+
+    return next(i for i, x in enumerate(spec_bodies) if x == body)
 
 
 def is_kinematic(body: mujoco.MjsBody, physics_prim: Usd.Prim) -> bool:

--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -90,6 +90,11 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
             # so we leave them free to be recomputed from geometry.
             body_id = get_model_body_id(body, data)
             mass = float(data.model.body_mass[body_id]) if body_id is not None else 0.0
+            # A compiled mass of 0 is never baked: authored physics:mass = 0 is the
+            # schema fallback value, so readers honoring MassAPI value semantics
+            # (e.g. Newton since newton-physics/newton#3418) treat it as unspecified
+            # and recompute from geometry, while older readers zero the mass out --
+            # the same authored value would mean different things to different readers.
             if mass > 0.0:
                 mass_api: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(body_over)
                 mass_api.CreateMassAttr().Set(mass)

--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -79,6 +79,23 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
                 if not np.isnan(body.fullinertia[0]):
                     body_over.ApplyAPI("NewtonMassAPI")
                     set_schema_attribute(body_over, "newton:inertia", Vt.DoubleArray.FromNumpy(body.fullinertia))
+        else:
+            # Author body-level mass/inertia from the compiled model so downstream
+            # readers honor it authoritatively. Without this, a rigid body with
+            # multiple collision shapes can have its mass recomputed from geometry
+            # (e.g. the Newton USD import), diverging from MuJoCo's body inertia.
+            if data.model is None:
+                data.model = data.spec.compile()
+            bid = data.model.body(body.name).id
+            bmass = float(data.model.body_mass[bid])
+            if bmass > 0.0:
+                mass_api: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(body_over)
+                mass_api.CreateMassAttr().Set(bmass)
+                mass_api.CreateCenterOfMassAttr().Set(convert_vec3d(data.model.body_ipos[bid]))
+                inertia = convert_vec3d(data.model.body_inertia[bid])
+                if inertia != Gf.Vec3f(0, 0, 0):
+                    mass_api.CreatePrincipalAxesAttr().Set(convert_quatf(data.model.body_iquat[bid]).GetNormalized())
+                    mass_api.CreateDiagonalInertiaAttr().Set(inertia)
 
         convert_joints(parent=body_over, body=body, data=data)
 

--- a/mujoco_usd_converter/_impl/data.py
+++ b/mujoco_usd_converter/_impl/data.py
@@ -36,3 +36,6 @@ class ConversionData:
     name_cache: usdex.core.NameCache
     scene: bool
     comment: str
+    # set when the compiled model cannot provide reliable per-body data, either
+    # because compilation failed or because it restructured the body tree
+    model_unavailable: bool = False

--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -276,26 +276,26 @@ def bind_material(geom_prim: Usd.Prim, name: str, data: ConversionData):
     usdex.core.bindMaterial(geom_over, material_prim)
 
 
-def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionData):
+def is_physics_geom(geom: mujoco.MjsGeom, data: ConversionData) -> bool:
     # most geom are colliders
-    is_collider = True
-    collider_enabled = True
+    # some geom are for vizualization only, but still contribute to the mass of the body
+    if geom.contype == 0 and geom.conaffinity == 0:
+        if data.spec.compiler.inertiafromgeom == mujoco.mjtInertiaFromGeom.mjINERTIAFROMGEOM_FALSE:
+            return False
+        if geom.group not in range(data.spec.compiler.inertiagrouprange[0], data.spec.compiler.inertiagrouprange[1] + 1):
+            return False
+        return not np.isnan(geom.mass) or geom.density > 0.0
+    return True
+
+
+def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionData):
+    is_collider = is_physics_geom(geom, data)
+    # visual-only geoms that contribute mass are kept as disabled colliders
+    collider_enabled = geom.contype != 0 or geom.conaffinity != 0
 
     # Tendons target non-collision geoms by name, so keep a mujoco name to USD path mapping
     if geom.name:
         data.geom_targets[geom.name] = geom_prim.GetPath()
-
-    # some geom are for vizualization only, but still contribute to the mass of the body
-    if geom.contype == 0 and geom.conaffinity == 0:
-        if data.spec.compiler.inertiafromgeom != mujoco.mjtInertiaFromGeom.mjINERTIAFROMGEOM_FALSE and (
-            geom.group in range(data.spec.compiler.inertiagrouprange[0], data.spec.compiler.inertiagrouprange[1] + 1)
-        ):
-            if not np.isnan(geom.mass) or geom.density > 0.0:
-                collider_enabled = False
-            else:
-                is_collider = False
-        else:
-            is_collider = False
 
     if not is_collider:
         # this is a purely visual geom, so we skip physics authoring

--- a/tests/data/discardvisual.xml
+++ b/tests/data/discardvisual.xml
@@ -1,0 +1,15 @@
+<mujoco model="discardvisual">
+    <compiler discardvisual="true"/>
+    <worldbody>
+        <body name="first" pos="0 0 0.5">
+            <joint type="hinge"/>
+            <geom type="box" size="0.1 0.1 0.1" mass="0.3"/>
+            <geom type="sphere" size="0.05" pos="0 0 0.2" mass="0.3"/>
+        </body>
+        <body name="second" pos="1 0 0.5">
+            <joint type="hinge"/>
+            <geom name="vis2" type="box" size="0.1 0.1 0.1" contype="0" conaffinity="0" rgba="1 0 0 1"/>
+            <geom name="col2" type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+</mujoco>

--- a/tests/data/fusestatic.xml
+++ b/tests/data/fusestatic.xml
@@ -1,0 +1,19 @@
+<mujoco model="fusestatic">
+    <compiler fusestatic="true"/>
+    <worldbody>
+        <body name="root" pos="0 0 1">
+            <freejoint/>
+            <geom type="box" size="0.1 0.1 0.1"/>
+            <body name="static_child" pos="0 0 0.3">
+                <geom type="box" size="0.05 0.05 0.05" mass="0.1"/>
+                <geom type="sphere" size="0.05" pos="0 0 0.15" mass="0.1"/>
+            </body>
+        </body>
+        <!-- a second multi-geom body must not repeat the compilation attempt or the warning -->
+        <body name="other" pos="1 0 1">
+            <freejoint/>
+            <geom type="box" size="0.1 0.1 0.1" mass="0.2"/>
+            <geom type="sphere" size="0.05" pos="0 0 0.2" mass="0.2"/>
+        </body>
+    </worldbody>
+</mujoco>

--- a/tests/data/inferred_inertia.xml
+++ b/tests/data/inferred_inertia.xml
@@ -34,5 +34,14 @@
         <body pos="4 0 0">
             <geom type="box" size="0.1 0.1 0.1"/>
         </body>
+
+        <!-- every collider is massless, so the compiled body mass is 0: the body-level
+             bake must be skipped, because an authored physics:mass = 0 is the schema
+             fallback value -- readers honoring MassAPI value semantics treat it as
+             unspecified (recomputing from geometry) while others zero the mass out -->
+        <body name="zero_mass_colliders" pos="6 0 0">
+            <geom type="box" size="0.1 0.1 0.1" mass="0"/>
+            <geom type="sphere" size="0.05" pos="0 0 0.25" density="0"/>
+        </body>
     </worldbody>
 </mujoco>

--- a/tests/data/inferred_inertia.xml
+++ b/tests/data/inferred_inertia.xml
@@ -1,0 +1,38 @@
+<mujoco model="inferred_inertia">
+    <worldbody>
+        <!-- several geoms contribute mass, so the inferred inertial is authored on the body -->
+        <body name="multi_geom" pos="1 0 0">
+            <geom type="box" size="0.1 0.05 0.02" pos="0.1 0 0" euler="0 0 30" mass="0.5"/>
+            <geom type="sphere" size="0.05" pos="-0.1 0 0.05"/>
+            <geom type="box" size="0.02 0.02 0.02" pos="0 0.1 0" mass="0"/>
+            <!-- nested unnamed body resolved positionally in the compiled model -->
+            <body pos="0 0 0.4">
+                <geom type="sphere" size="0.04" mass="0.2"/>
+                <geom type="sphere" size="0.04" pos="0 0 0.1" mass="0.3"/>
+            </body>
+        </body>
+
+        <!-- a massless collider (density="0") authors no geom-level mass properties,
+             so the body-level inertial is required to reproduce the MuJoCo mass -->
+        <body name="massless_collider" pos="5 0 0">
+            <geom type="box" size="0.1 0.1 0.1" mass="0.5"/>
+            <geom type="sphere" size="0.05" pos="0 0 0.25" density="0"/>
+        </body>
+
+        <!-- a single geom contributes mass, so the geom-level properties are sufficient -->
+        <body name="single_geom" pos="2 0 0">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+
+        <!-- unnamed body with an inferred inertial from several geoms -->
+        <body pos="3 0 0">
+            <geom type="box" size="0.1 0.1 0.1"/>
+            <geom type="sphere" size="0.05" pos="0 0 0.2"/>
+        </body>
+
+        <!-- unnamed body with a single geom -->
+        <body pos="4 0 0">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+</mujoco>

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -223,6 +223,16 @@ class TestInferredInertia(ConverterTestCase):
         self.assertBodyMassMatchesModel(prim, self.mj_model.body("massless_collider").id)
         self.assertAlmostEqual(UsdPhysics.MassAPI(prim).GetMassAttr().Get(), 0.5, places=6)
 
+    def test_zero_compiled_mass_body_is_not_baked(self):
+        # a multi-collider body whose compiled mass is 0 must not get a body-level
+        # MassAPI: authored physics:mass = 0 is the schema fallback value, which
+        # value-semantics readers (Newton since newton-physics/newton#3418) treat as
+        # unspecified while older readers zero the mass out
+        self.assertEqual(self.mj_model.body("zero_mass_colliders").mass[0], 0.0)
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/inferred_inertia/Geometry/zero_mass_colliders")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+
 
 class TestCompilerOverrides(ConverterTestCase):
     """Compiler settings that mutate the spec during compilation must not affect conversion"""

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -4,7 +4,9 @@ import pathlib
 
 import mujoco
 import numpy as np
-from pxr import Gf, Sdf, Usd, UsdPhysics
+import usdex.core
+import usdex.test
+from pxr import Gf, Sdf, Tf, Usd, UsdGeom, UsdPhysics
 
 import mujoco_usd_converter
 from tests.util.ConverterTestCase import ConverterTestCase
@@ -136,3 +138,123 @@ class TestBodies(ConverterTestCase):
         self.assertEqual(mass_api.GetCenterOfMassAttr().Get(), Gf.Vec3f(0.1, 0.2, 0.3))
         self.assertFalse(mass_api.GetPrincipalAxesAttr().HasAuthoredValue())
         self.assertFalse(mass_api.GetDiagonalInertiaAttr().HasAuthoredValue())
+
+
+class TestInferredInertia(ConverterTestCase):
+    """Bodies without an explicit inertial, whose mass properties are inferred from geoms
+
+    When several geoms contribute mass, the compiled body-level mass properties are
+    authored so downstream readers reproduce MuJoCo's inferred inertial unambiguously.
+    Single-geom bodies rely on the geom-level mass properties alone.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.model = pathlib.Path("./tests/data/inferred_inertia.xml")
+        asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(self.model, self.tmpDir())
+        self.stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(self.stage)
+        self.mj_model: mujoco.MjModel = mujoco.MjModel.from_xml_path(str(self.model))
+
+    def assertBodyMassMatchesModel(self, prim: Usd.Prim, body_id: int):  # noqa: N802
+        self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
+        mass_api = UsdPhysics.MassAPI(prim)
+        self.assertAlmostEqual(mass_api.GetMassAttr().Get(), self.mj_model.body_mass[body_id], places=5)
+        expected_com = Gf.Vec3f(*self.mj_model.body_ipos[body_id])
+        self.assertTrue(Gf.IsClose(mass_api.GetCenterOfMassAttr().Get(), expected_com, 1e-5))
+        expected_inertia = Gf.Vec3f(*self.mj_model.body_inertia[body_id])
+        self.assertTrue(Gf.IsClose(mass_api.GetDiagonalInertiaAttr().Get(), expected_inertia, 1e-5))
+        quat = self.mj_model.body_iquat[body_id]
+        expected_axes = Gf.Quatf(float(quat[0]), Gf.Vec3f(float(quat[1]), float(quat[2]), float(quat[3])))
+        self.assertRotationsAlmostEqual(mass_api.GetPrincipalAxesAttr().Get(), expected_axes)
+
+    def test_multi_geom_body(self):
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/inferred_inertia/Geometry/multi_geom")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(prim.HasAPI("NewtonMassAPI"))
+        self.assertBodyMassMatchesModel(prim, self.mj_model.body("multi_geom").id)
+
+    def test_single_geom_body(self):
+        # the geom-level mass properties are authoritative, so no body-level MassAPI is authored
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/inferred_inertia/Geometry/single_geom")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertFalse(prim.HasAPI("NewtonMassAPI"))
+
+    def test_unnamed_bodies(self):
+        # unnamed bodies must convert successfully, including the compiled model
+        # lookup for multi-geom bodies, which cannot be resolved by name
+        prims = [x for x in self.stage.GetPrimAtPath("/inferred_inertia/Geometry").GetChildren() if x.GetName().startswith("Body")]
+        self.assertEqual(len(prims), 2)
+
+        spec = mujoco.MjSpec.from_file(str(self.model))
+        spec.compile()
+        unnamed_ids = [x.id for x in spec.worldbody.bodies if not x.name]
+        self.assertEqual(len(unnamed_ids), 2)
+
+        def gprim_count(prim: Usd.Prim) -> int:
+            return len([x for x in prim.GetChildren() if x.IsA(UsdGeom.Gprim)])
+
+        multi_geom_prim, single_geom_prim = prims
+        if gprim_count(multi_geom_prim) == 1:
+            multi_geom_prim, single_geom_prim = single_geom_prim, multi_geom_prim
+        self.assertEqual(gprim_count(multi_geom_prim), 2)
+        self.assertEqual(gprim_count(single_geom_prim), 1)
+
+        self.assertTrue(multi_geom_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertBodyMassMatchesModel(multi_geom_prim, unnamed_ids[0])
+
+        self.assertTrue(single_geom_prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(single_geom_prim.HasAPI(UsdPhysics.MassAPI))
+
+    def test_nested_unnamed_body(self):
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/inferred_inertia/Geometry/multi_geom/Body")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        spec = mujoco.MjSpec.from_file(str(self.model))
+        spec.compile()
+        nested_body = spec.worldbody.bodies[0].bodies[0]
+        self.assertBodyMassMatchesModel(prim, nested_body.id)
+
+    def test_massless_collider_body(self):
+        # the massless density="0" collider authors no geom-level mass properties, so the
+        # body-level inertial is required for downstream readers to reproduce the mass
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/inferred_inertia/Geometry/massless_collider")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertBodyMassMatchesModel(prim, self.mj_model.body("massless_collider").id)
+        self.assertAlmostEqual(UsdPhysics.MassAPI(prim).GetMassAttr().Get(), 0.5, places=6)
+
+
+class TestCompilerOverrides(ConverterTestCase):
+    """Compiler settings that mutate the spec during compilation must not affect conversion"""
+
+    def test_fusestatic(self):
+        # compiling a spec with fusestatic restructures the body tree, so no body-level
+        # mass properties can be transferred, but the conversion itself must be unaffected
+        model = pathlib.Path("./tests/data/fusestatic.xml")
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Body-level mass properties will not be authored.*")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir())
+        stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+        self.assertTrue(stage.GetPrimAtPath("/fusestatic/Geometry/root/static_child"))
+        for prim in stage.Traverse():
+            if prim.HasAPI(UsdPhysics.RigidBodyAPI):
+                self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+
+    def test_discardvisual(self):
+        # compiling a spec with discardvisual removes visual geoms from the compiled spec;
+        # the converted USD must keep them, while the body-level mass still matches MuJoCo
+        model = pathlib.Path("./tests/data/discardvisual.xml")
+        asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir())
+        stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+        self.assertTrue(stage.GetPrimAtPath("/discardvisual/Geometry/second/vis2"))
+        mj_model = mujoco.MjModel.from_xml_path(str(model))
+        for name in ("first", "second"):
+            prim = stage.GetPrimAtPath(f"/discardvisual/Geometry/{name}")
+            self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
+            mass_api = UsdPhysics.MassAPI(prim)
+            self.assertAlmostEqual(mass_api.GetMassAttr().Get(), mj_model.body_mass[mj_model.body(name).id], places=5)

--- a/tests/testGeom.py
+++ b/tests/testGeom.py
@@ -421,10 +421,17 @@ class TestGeomVisualDefaultDensity(ConverterTestCase):
         self.assertIsValidUsd(self.stage)
 
     def test_visual_default_density(self):
+        # the visual geom's default density and the zero mass collision geom are ambiguous
+        # for readers that recompute mass from geometry, so the body authors the inferred inertial
+        body_prim: Usd.Prim = self.stage.GetPrimAtPath("/geom_default_density/Geometry/test")
+        self.assertTrue(body_prim.HasAPI(UsdPhysics.MassAPI))
+        self.assertAlmostEqual(UsdPhysics.MassAPI(body_prim).GetMassAttr().Get(), 8.0, places=6)
+
+        # the geom-level mass properties must still support density-based recomputation
         total_mass = 0.0
         bbox_cache = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_])
         for prim in self.stage.Traverse():
-            if prim.HasAPI(UsdPhysics.MassAPI):
+            if prim.HasAPI(UsdPhysics.MassAPI) and prim.IsA(UsdGeom.Gprim):
                 mass_api = UsdPhysics.MassAPI(prim)
                 density = mass_api.GetDensityAttr().Get()
                 if mass_api.GetMassAttr().HasAuthoredValue():


### PR DESCRIPTION
Fixes #100

## What

For a body without an explicit `<inertial>` whose mass properties are inferred from **more than one collider shape**, author the compiled body-level mass properties (`physics:mass`, `physics:centerOfMass`, `physics:diagonalInertia`, `physics:principalAxes`) on the rigid-body prim, so the converted USD unambiguously reproduces MuJoCo's inferred inertial.

Single-shape bodies are unchanged: their geom-level `physics:mass`/`physics:density` remain the only authored mass properties, and downstream readers remain free to recompute them from geometry.

## Why body-level authoring is needed (#100)

Downstream readers can combine multiple collider shapes differently than MuJoCo does — Newton's USD import recomputes multi-shape bodies from geometry, ignoring per-geom authored `physics:mass`. Massless `density="0"` colliders author no mass properties at all, so a reader has nothing to reproduce MuJoCo's mass from. On Menagerie SO-101 this produced a ~0.6% total-mass / ~1.8% gravity-torque error; for a `mass="0.5"` + `density="0"` two-geom body the divergence is unbounded (recomputed ~16 kg vs 0.5 kg).

## Implementation notes

- The compiled model is always built from a **copy** of the spec. Compiling the live spec mid-conversion is not safe: with `<compiler fusestatic="true"/>` a successful compile removes fused bodies from the spec and invalidates live `MjsBody` handles (observed segfaults), and with `<compiler discardvisual="true"/>` it deletes visual geoms from bodies that have not been converted yet. Regression tests cover both.
- Body ids are resolved positionally: model body ids follow the spec's depth-first document order. This also works for unnamed bodies, which cannot be resolved by name (`data.model.body("")` raises). Covered by top-level and nested unnamed-body tests.
- If the model cannot be compiled (some models are intentionally convertible without compiling, e.g. `tests/data/meshes.xml`), or compilation restructures the body tree (`fusestatic`), the body-level authoring is skipped with a single warning and conversion proceeds as before.
- `apply_physics` in `geom.py` now shares the new `is_physics_geom` predicate (behavior unchanged) so the trigger condition cannot drift from what is actually authored.
- `test_visual_default_density` was updated: its fixture (a default-density visual geom + a zero-mass collision geom) is exactly the ambiguous multi-shape case, so the body now intentionally carries the inferred inertial; the geom-level density recomputation check is preserved.

## Testing

- `poe test`: 185/185 pass; `poe lint` clean.
- End-to-end on Menagerie SO-101: all 8 bodies author body-level mass matching `mjModel.body_mass` exactly (`camera_mount` = 0.012).
- Menagerie `umi_gripper.xml` (unnamed body) converts successfully.
- **Newton A/B acceptance** (newton 1.4.0, `ModelBuilder.add_usd` on the converted SO-101): with `main`'s output Newton reads `camera_mount` = 0.01598 / total = 0.64799 (the exact divergence from #100); with this branch's output all 8 bodies match `mjModel.body_mass` to float32 precision (`camera_mount` = 0.01200, total = 0.64401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

