### PR TITLE
Author mass XOR density on geoms, never both

### DIFF
--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -349,8 +349,11 @@ def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionDat
     if not np.isnan(geom.mass):
         geom_mass: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(geom_over)
         geom_mass.CreateMassAttr().Set(geom.mass)
-
-    if geom.density > 0.0:
+    elif geom.density > 0.0:
+        # Only author density when mass is unspecified. Per MJCF docs:
+        # "If [mass] is specified, the density attribute is ignored."
+        # When mass IS specified, MuJoCo back-computes density from mass,
+        # so geom.density is non-zero but not an independent opinion.
         geom_mass: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(geom_over)
         geom_mass.CreateDensityAttr().Set(geom.density)
 

--- a/tests/testGeom.py
+++ b/tests/testGeom.py
@@ -124,8 +124,8 @@ class TestGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
         mass_api = UsdPhysics.MassAPI(prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 5.0)
-        self.assertTrue(mass_api.GetDensityAttr().HasAuthoredValue())
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 1000.0)
+        # Density is NOT authored when mass is specified (mass XOR density)
+        self.assertFalse(mass_api.GetDensityAttr().HasAuthoredValue())
         self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), UsdGeom.Tokens.default_)
 
     def test_visual_with_density(self):
@@ -174,8 +174,8 @@ class TestGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
         mass_api = UsdPhysics.MassAPI(prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 10.0)
-        self.assertTrue(mass_api.GetDensityAttr().HasAuthoredValue())
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 1000.0)
+        # Density is NOT authored when mass is specified (mass XOR density)
+        self.assertFalse(mass_api.GetDensityAttr().HasAuthoredValue())
 
     def test_explicit_density(self):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/explicit_density")
@@ -186,12 +186,19 @@ class TestGeom(ConverterTestCase):
         self.assertFalse(mass_api.GetMassAttr().HasAuthoredValue())
 
     def test_mass_and_density(self):
+        """When MJCF specifies both mass and density, only mass is authored in USD.
+
+        Per MJCF docs: 'If [mass] is specified, the density attribute is ignored.'
+        The density value in the compiled spec is either the authored density
+        (ignored by MuJoCo) or back-computed — either way it's not an independent
+        opinion and should not be emitted."""
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/mass_and_density")
         self.assertTrue(prim.HasAPI(UsdPhysics.CollisionAPI))
         self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
         mass_api = UsdPhysics.MassAPI(prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 15.0)
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 4000)
+        # Density is NOT authored when mass is specified (mass XOR density)
+        self.assertFalse(mass_api.GetDensityAttr().HasAuthoredValue())
 
     def test_shell_inertia(self):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/shell_inertia")
@@ -382,8 +389,8 @@ class TestGeomInertiaFromGeom(ConverterTestCase):
         self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
         mass_api = UsdPhysics.MassAPI(prim)
         self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 10.0)
-        self.assertTrue(mass_api.GetDensityAttr().HasAuthoredValue())
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 1000.0)
+        # Density is NOT authored when mass is specified (mass XOR density)
+        self.assertFalse(mass_api.GetDensityAttr().HasAuthoredValue())
 
     def test_explicit_density(self):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/explicit_density")


### PR DESCRIPTION
## Summary

Per MJCF docs: *"If [mass] is specified, the density attribute is ignored."*

When a geom has an explicit mass, MuJoCo back-computes density from mass. Previously the converter authored both `physics:mass` and `physics:density`, which misled downstream USD mass aggregation into using a density opinion the source never intended.

Now: author `physics:mass` when `geom.mass` is specified, otherwise author `physics:density` when `geom.density > 0`. Never both.

## Changes

- `geom.py`: gated density authoring behind `np.isnan(geom.mass)` (`elif` instead of independent `if`)
- Updated tests: explicit-mass and mass-and-density cases now assert density is NOT authored
- CHANGELOG entry

## Test plan

```
uv run python -m unittest discover tests -v  # 178 tests passed
```

Relates to #100.