### PR TITLE
Author newton:mimicCoef0 in degrees for angular followers

### DIFF
--- a/mujoco_usd_converter/_impl/equality.py
+++ b/mujoco_usd_converter/_impl/equality.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import mujoco
+import numpy as np
 import usdex.core
 from pxr import Gf, Tf, Usd, UsdGeom, Vt
 
@@ -169,10 +170,19 @@ def convert_equality(
             Tf.Warn(f"Joint '{equality.name2}' not found for equality '{equality.name}'")
             return equality_prim, False
 
+        # NewtonMimicAPI authors coef0 in the follower joint's position units, which is
+        # degrees for an angular joint. MuJoCo's polycoef[0] is always radians -- unlike
+        # joint ranges it is not affected by compiler.degree -- so convert on joint type
+        # alone. coef1 is dimensionless in both.
+        coef0 = equality.data[0]
+        follower = data.spec.joint(equality.name1)
+        if follower is not None and follower.type in (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_BALL):
+            coef0 = np.degrees(coef0)
+
         # Apply the NewtonMimicAPI schema
         joint_prim.ApplyAPI("NewtonMimicAPI")
         set_schema_attribute(joint_prim, "newton:mimicEnabled", equality.active)
-        set_schema_attribute(joint_prim, "newton:mimicCoef0", equality.data[0])
+        set_schema_attribute(joint_prim, "newton:mimicCoef0", coef0)
         set_schema_attribute(joint_prim, "newton:mimicCoef1", equality.data[1])
         joint_prim.GetRelationship("newton:mimicJoint").SetTargets([target_joint_path])
 

--- a/tests/data/equality_joint_attributes.xml
+++ b/tests/data/equality_joint_attributes.xml
@@ -39,7 +39,7 @@
            joint2="slide1"
            solimp="0.9 0.95 0.001 0.5 2"
            solref="0.02 1"
-           polycoef="0 1 0 0 0"/>
+           polycoef="0.25 1 0 0 0"/>
     <!-- Disabled joint equality: active="false" → physics:jointEnabled authored and false -->
     <joint name="disabled_joint_eq"
            joint1="hinge2"

--- a/tests/testEqualities.py
+++ b/tests/testEqualities.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
+import math
 import pathlib
 
 import usdex.test
@@ -332,7 +333,9 @@ class TestEqualities(ConverterTestCase):
 
         # Check NewtonMimicAPI attributes
         self.assertTrue(custom_joint.HasAPI("NewtonMimicAPI"))
-        self.assertAlmostEqual(custom_joint.GetAttribute("newton:mimicCoef0").Get(), 0.5)
+        # polycoef[0] is radians; NewtonMimicAPI defines coef0 in the follower's position
+        # units, so a hinge follower is authored in degrees.
+        self.assertAlmostEqual(custom_joint.GetAttribute("newton:mimicCoef0").Get(), math.degrees(0.5), places=4)
         self.assertAlmostEqual(custom_joint.GetAttribute("newton:mimicCoef1").Get(), 1.5)
         targets = custom_joint.GetRelationship("newton:mimicJoint").GetTargets()
         self.assertEqual(len(targets), 1)
@@ -371,7 +374,8 @@ class TestEqualities(ConverterTestCase):
 
         # Check NewtonMimicAPI attributes
         self.assertTrue(default_joint.HasAPI("NewtonMimicAPI"))
-        self.assertAlmostEqual(default_joint.GetAttribute("newton:mimicCoef0").Get(), 0.0)
+        # A slide follower carries distance units, so polycoef[0] passes through unscaled.
+        self.assertAlmostEqual(default_joint.GetAttribute("newton:mimicCoef0").Get(), 0.25, places=6)
         self.assertAlmostEqual(default_joint.GetAttribute("newton:mimicCoef1").Get(), 1.0)
         targets = default_joint.GetRelationship("newton:mimicJoint").GetTargets()
         self.assertEqual(len(targets), 1)
@@ -381,7 +385,14 @@ class TestEqualities(ConverterTestCase):
         self.assertAlmostEqual(default_joint.GetAttribute("newton:limitDamping").Get(), 100)
 
         # Check that only required relationships and Newton joint values whose schema defaults differ are authored.
-        authored_properties = ["newton:mimicJoint", "newton:limitStiffness", "newton:limitDamping"]
+        # mimicCoef0 is authored here because the fixture gives the slide follower a
+        # non-zero offset; a zero offset would match the schema default and be skipped.
+        authored_properties = [
+            "newton:mimicJoint",
+            "newton:mimicCoef0",
+            "newton:limitStiffness",
+            "newton:limitDamping",
+        ]
         for property in default_joint.GetPropertiesInNamespace("newton"):
             if property.GetName() in authored_properties:
                 self.assertTrue(self.__has_authored_value(property), f"Property {property.GetName()} is not authored")


### PR DESCRIPTION
## Description

Author `newton:mimicCoef0` in degrees for angular follower joints.

MuJoCo's `polycoef[0]` is the constant offset in `joint0 = coef0 + coef1 * joint1` and is expressed in radians. `NewtonMimicAPI` documents `newton:mimicCoef0` as "distance or degrees (matches the joint type)", so hinge and ball followers were authored a factor of `180/pi` too small. Slide followers are already in distance units and are unaffected, as is the dimensionless `newton:mimicCoef1`.

Fixes #107.

### Why this is not gated on `compiler.degree`

`get_limits()` two functions away *does* check `compiler.degree`, so the obvious question is why this does not. `polycoef` is never angle-converted by MuJoCo — it is radians in MJCF regardless of `<compiler angle=...>`.

From MuJoCo's source, `compiler->degree` gates only joint `range` (`user_objects.cc:3217`), joint `ref`/`springref` (`user_objects.cc:3279`), and euler orientation resolution. `mjCEquality::Compile()` never touches `data[]`; the XML reader takes `polycoef` straight into `equality->data` and the writer emits it back unchanged.

Confirmed on the compiled model — same file, same setting, ranges convert and polycoef does not:

```
angle=radian  spec.joint.range[0]=-1.000000   -> compiled jnt_range[0]=-1.000000
angle=degree  spec.joint.range[0]=-57.295780  -> compiled jnt_range[0]=-1.000000   (converted)
angle=radian  spec.eq.data[0]=0.5             -> compiled eq_data[0]=0.500000
angle=degree  spec.eq.data[0]=0.5             -> compiled eq_data[0]=0.500000      (not converted)
```

Gating on `compiler.degree` would therefore double-convert degree-authored files. This matches the note in #107 that the MuJoCo USD decoder must not gate on that flag either, for the same reason.

### Test fixture

The slide case in `equality_joint_attributes.xml` used `polycoef="0 1 0 0 0"`. A zero offset cannot distinguish a missing conversion from a correct one, so it now carries a non-zero offset and asserts the value passes through unscaled. That makes `newton:mimicCoef0` authored on that joint, hence its addition to the expected authored-property list in `test_joint_equality_schema`.

Reverting the conversion fails with `0.5 != 28.64788975654116`.

### Sequencing

Newton's USD importer has the same missing conversion, so the two currently agree with each other and disagree with the schema. **Landing this alone makes MJCF → USD → Newton round trips wrong by `180/pi`.** The Newton-side fix is prepared and should land first or together with this. See also newton-physics/urdf-usd-converter#134 for the equivalent URDF fix, and newton-physics/newton-usd-schemas#80 documenting the related same-joint-type requirement.

Assets produced by earlier versions hold radian values in a degrees field and need reconverting rather than re-blessing.

No changelog entry, per the release-prep workflow.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).

## Test plan

```
uv run python -m unittest discover -s ./tests   # 178 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
