### PR TITLE
Bake body mass only when a visual provides it

### DIFF
--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -4,7 +4,7 @@
 import mujoco
 import numpy as np
 import usdex.core
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics, Vt
+from pxr import Gf, Sdf, Tf, Usd, UsdGeom, UsdPhysics, Vt
 
 from .data import ConversionData, Tokens
 from .geom import convert_geom, get_geom_name
@@ -18,6 +18,68 @@ __all__ = ["convert_bodies"]
 def convert_bodies(data: ConversionData):
     geo_scope = data.content[Tokens.Geometry].GetDefaultPrim().GetChild(Tokens.Geometry).GetPrim()
     convert_body(parent=geo_scope, name=data.spec.modelname, body=data.spec.worldbody, data=data)
+
+
+def requires_mass_bake(body: mujoco.MjsBody, data: ConversionData) -> bool:
+    """Whether this body's mass depends on a geom that USD cannot accumulate mass from.
+
+    MuJoCo infers body mass from every geom in ``inertiagrouprange``, including non-colliding
+    ones. USD accumulates only from enabled colliders, so such a body needs explicit mass.
+
+    Bodies whose mass comes solely from colliders are left alone: their mass is described as
+    the source expressed it, and baking would override an author's implicit intent.
+    """
+    if data.spec.compiler.inertiafromgeom == mujoco.mjtInertiaFromGeom.mjINERTIAFROMGEOM_FALSE:
+        return False
+    lower, upper = data.spec.compiler.inertiagrouprange
+    for geom in body.geoms:
+        if geom.contype != 0 or geom.conaffinity != 0:
+            continue  # a collider; USD accumulates its mass
+        if not lower <= geom.group <= upper:
+            continue  # MuJoCo does not count it either
+        if not np.isnan(geom.mass):
+            if geom.mass > 0.0:
+                return True
+        elif geom.density > 0.0:
+            return True
+    return False
+
+
+def _compiled_body(body: mujoco.MjsBody, data: ConversionData) -> mujoco.MjsBody | None:
+    """Return ``body`` as compiled by MuJoCo, without disturbing the spec being converted.
+
+    Compilation is what assigns body ids, so the lookup goes by position in the spec, which
+    the compiled copy preserves.
+    """
+    try:
+        model = data.get_model()
+    except Exception as e:
+        Tf.Warn(f"Unable to compile the model to bake mass for body '{body.name}': {e}")
+        return None
+
+    index = next((i for i, b in enumerate(data.spec.bodies) if b is body), None)
+    if index is None or index >= model.nbody:
+        Tf.Warn(f"Unable to locate body '{body.name}' in the compiled model; mass not baked.")
+        return None
+    return model.body(index)
+
+
+def bake_body_mass(body: mujoco.MjsBody, body_over: Usd.Prim, data: ConversionData) -> None:
+    """Author MuJoCo's compiled mass, centre of mass and inertia on the body prim.
+
+    See :func:`requires_mass_bake` for when a body needs this.
+    """
+    compiled = _compiled_body(body, data)
+    if compiled is None:
+        return
+
+    mass_api: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(body_over)
+    mass_api.CreateMassAttr().Set(float(compiled.mass[0]))
+    mass_api.CreateCenterOfMassAttr().Set(convert_vec3d(compiled.ipos))
+    inertia = convert_vec3d(compiled.inertia)
+    if inertia != Gf.Vec3f(0, 0, 0):
+        mass_api.CreatePrincipalAxesAttr().Set(convert_quatf(compiled.iquat).GetNormalized())
+        mass_api.CreateDiagonalInertiaAttr().Set(inertia)
 
 
 def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: ConversionData) -> UsdGeom.Xform:
@@ -79,6 +141,8 @@ def convert_body(parent: Usd.Prim, name: str, body: mujoco.MjsBody, data: Conver
                 if not np.isnan(body.fullinertia[0]):
                     body_over.ApplyAPI("NewtonMassAPI")
                     set_schema_attribute(body_over, "newton:inertia", Vt.DoubleArray.FromNumpy(body.fullinertia))
+        elif requires_mass_bake(body, data):
+            bake_body_mass(body, body_over, data)
 
         convert_joints(parent=body_over, body=body, data=data)
 

--- a/mujoco_usd_converter/_impl/body.py
+++ b/mujoco_usd_converter/_impl/body.py
@@ -45,23 +45,22 @@ def requires_mass_bake(body: mujoco.MjsBody, data: ConversionData) -> bool:
     return False
 
 
-def _compiled_body(body: mujoco.MjsBody, data: ConversionData) -> mujoco.MjsBody | None:
-    """Return ``body`` as compiled by MuJoCo, without disturbing the spec being converted.
+def get_model_body_id(body: mujoco.MjsBody, model: mujoco.MjModel, data: ConversionData) -> int | None:
+    """Return the compiled body id for a spec body, or ``None`` if it cannot be located.
 
-    Compilation is what assigns body ids, so the lookup goes by position in the spec, which
-    the compiled copy preserves.
+    The match is positional: ``MjSpec.bodies`` is the body tree flattened depth-first, which is
+    the order the compiler assigns ids in. Composition happens before compilation and preserves
+    that agreement -- ``attach`` splices the attached subtree into both orderings at the same
+    point, and ``replicate`` expands into the spec as named clones.
+
+    Name is not a usable key here: a body name is optional, so every unnamed body shares the
+    empty name. Nor is ``MjsBody.id``, which is -1 until the spec itself is compiled, and this
+    compiles a copy to leave the spec being converted untouched.
     """
-    try:
-        model = data.get_model()
-    except Exception as e:
-        Tf.Warn(f"Unable to compile the model to bake mass for body '{body.name}': {e}")
-        return None
-
     index = next((i for i, b in enumerate(data.spec.bodies) if b is body), None)
     if index is None or index >= model.nbody:
-        Tf.Warn(f"Unable to locate body '{body.name}' in the compiled model; mass not baked.")
         return None
-    return model.body(index)
+    return index
 
 
 def bake_body_mass(body: mujoco.MjsBody, body_over: Usd.Prim, data: ConversionData) -> None:
@@ -69,9 +68,17 @@ def bake_body_mass(body: mujoco.MjsBody, body_over: Usd.Prim, data: ConversionDa
 
     See :func:`requires_mass_bake` for when a body needs this.
     """
-    compiled = _compiled_body(body, data)
-    if compiled is None:
+    try:
+        model = data.get_model()
+    except Exception as e:
+        Tf.Warn(f"Unable to compile the model to bake mass for body '{body.name}': {e}")
         return
+
+    body_id = get_model_body_id(body, model, data)
+    if body_id is None:
+        Tf.Warn(f"Unable to locate body '{body.name}' in the compiled model; mass not baked.")
+        return
+    compiled = model.body(body_id)
 
     mass_api: UsdPhysics.MassAPI = UsdPhysics.MassAPI.Apply(body_over)
     mass_api.CreateMassAttr().Set(float(compiled.mass[0]))

--- a/mujoco_usd_converter/_impl/data.py
+++ b/mujoco_usd_converter/_impl/data.py
@@ -36,3 +36,13 @@ class ConversionData:
     name_cache: usdex.core.NameCache
     scene: bool
     comment: str
+
+    def get_model(self) -> mujoco.MjModel:
+        """Compile the spec on demand, caching the result. Raises if compilation fails.
+
+        A copy is compiled because ``MjSpec.compile()`` mutates the spec it is called on,
+        and conversion reads from the spec throughout.
+        """
+        if self.model is None:
+            self.model = self.spec.copy().compile()
+        return self.model

--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -139,11 +139,10 @@ def get_mesh_fitting(geom: mujoco.MjsGeom, data: ConversionData) -> tuple[Gf.Vec
     if not hasattr(geom, "meshname") or not geom.meshname:
         return None, None, None
 
-    if data.model is None:
-        try:
-            data.model = data.spec.compile()
-        except Exception as e:
-            Tf.RaiseRuntimeError(f"Failed to compile model: {e}")
+    try:
+        data.get_model()
+    except Exception as e:
+        Tf.RaiseRuntimeError(f"Failed to compile model: {e}")
 
     geom_id = get_model_geom_id(geom, data)
     if geom_id is None:

--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -123,7 +123,10 @@ def get_model_geom_id(geom: mujoco.MjsGeom, data: ConversionData) -> int:
     # If no geom name is specified, the target geom is searched for within the parent body.
     parent_body = geom.parent
     if not parent_body.name:
-        Tf.Warn(f"Parent body name not found (geom id: {geom.id})")
+        # MjsGeom.id is only assigned by compiling the spec in place, which the converter avoids.
+        # A geom's position in the spec is the id the compiler assigns it, so report that instead.
+        geom_index = next((i for i, g in enumerate(data.spec.geoms) if g is geom), None)
+        Tf.Warn(f"Parent body name not found (geom id: {geom_index})")
         return None
 
     for i in range(data.model.ngeom):

--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -278,23 +278,14 @@ def bind_material(geom_prim: Usd.Prim, name: str, data: ConversionData):
 def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionData):
     # most geom are colliders
     is_collider = True
-    collider_enabled = True
 
     # Tendons target non-collision geoms by name, so keep a mujoco name to USD path mapping
     if geom.name:
         data.geom_targets[geom.name] = geom_prim.GetPath()
 
-    # some geom are for vizualization only, but still contribute to the mass of the body
+    # exclude visual geom from physics; any mass they carry is baked onto the body instead
     if geom.contype == 0 and geom.conaffinity == 0:
-        if data.spec.compiler.inertiafromgeom != mujoco.mjtInertiaFromGeom.mjINERTIAFROMGEOM_FALSE and (
-            geom.group in range(data.spec.compiler.inertiagrouprange[0], data.spec.compiler.inertiagrouprange[1] + 1)
-        ):
-            if not np.isnan(geom.mass) or geom.density > 0.0:
-                collider_enabled = False
-            else:
-                is_collider = False
-        else:
-            is_collider = False
+        is_collider = False
 
     if not is_collider:
         # this is a purely visual geom, so we skip physics authoring
@@ -305,9 +296,7 @@ def apply_physics(geom_prim: Usd.Prim, geom: mujoco.MjsGeom, data: ConversionDat
 
     geom_over: Usd.Prim = data.content[Tokens.Physics].OverridePrim(geom_prim.GetPrim().GetPath())
 
-    collider: UsdPhysics.CollisionAPI = UsdPhysics.CollisionAPI.Apply(geom_over)
-    if not collider_enabled:
-        collider.CreateCollisionEnabledAttr().Set(False)
+    UsdPhysics.CollisionAPI.Apply(geom_over)
 
     geom_over.ApplyAPI("NewtonCollisionAPI")
     geom_over.ApplyAPI("MjcCollisionAPI")

--- a/tests/data/bodies.xml
+++ b/tests/data/bodies.xml
@@ -49,6 +49,16 @@
             <geom type="box" size="0.1 0.1 0.1"/>
         </body>
 
+        <!-- mass comes from a non-colliding geom, which USD cannot accumulate: the body is baked -->
+        <body name="mass_from_visual" pos="6 0 0">
+            <geom type="box" size="0.1 0.1 0.1" contype="0" conaffinity="0" mass="3.0"/>
+            <geom type="box" size="0.1 0.1 0.1" contype="1" conaffinity="1" mass="1.0"/>
+        </body>
+        <!-- mass comes solely from colliders, so it is left to USD accumulation -->
+        <body name="mass_from_colliders" pos="7 0 0">
+            <geom type="box" size="0.1 0.1 0.1" mass="2.0"/>
+            <geom type="box" size="0.1 0.1 0.1" pos="0.5 0 0" mass="1.0"/>
+        </body>
         <body name="zero_inertia" pos="5 0 0">
             <inertial pos="0.1 0.2 0.3" mass="2" diaginertia="0 0 0"/>
             <geom type="box" size="0.1 0.1 0.1"/>

--- a/tests/data/mass_bake_attach.xml
+++ b/tests/data/mass_bake_attach.xml
@@ -1,0 +1,24 @@
+<!--
+    Attaching inserts the child bodies mid-tree, so every body after the attach point shifts.
+    Each body here carries a distinct mass, so a lookup that lost track of which compiled body
+    belongs to which spec body bakes a visibly wrong number rather than merely failing.
+-->
+<mujoco model="mass_bake_attach">
+    <asset>
+        <model name="child" file="mass_bake_child.xml"/>
+    </asset>
+
+    <worldbody>
+        <!-- mass comes solely from a collider, so it is left to USD accumulation -->
+        <body name="before">
+            <geom type="sphere" size="0.1" mass="2.0"/>
+            <attach model="child" body="visual_mass" prefix="attached_"/>
+        </body>
+
+        <!-- follows the attached subtree, so its compiled id is not its authored position -->
+        <body name="after" pos="1 0 0">
+            <geom type="box" size="0.1 0.1 0.1" contype="0" conaffinity="0" mass="9.0"/>
+            <geom type="box" size="0.1 0.1 0.1" contype="1" conaffinity="1" mass="1.0"/>
+        </body>
+    </worldbody>
+</mujoco>

--- a/tests/data/mass_bake_child.xml
+++ b/tests/data/mass_bake_child.xml
@@ -1,0 +1,12 @@
+<mujoco model="mass_bake_child">
+    <worldbody>
+        <!-- mass comes from a non-colliding geom, which USD cannot accumulate: the body is baked -->
+        <body name="visual_mass">
+            <geom type="box" size="0.1 0.1 0.1" contype="0" conaffinity="0" mass="5.0"/>
+            <geom type="box" size="0.1 0.1 0.1" contype="1" conaffinity="1" mass="1.0"/>
+            <body name="nested" pos="0 0 0.5">
+                <geom type="sphere" size="0.05" mass="0.25"/>
+            </body>
+        </body>
+    </worldbody>
+</mujoco>

--- a/tests/data/mass_bake_uncompilable.xml
+++ b/tests/data/mass_bake_uncompilable.xml
@@ -1,0 +1,12 @@
+<!--
+    The body needs its mass baked, which requires a compiled model, but the zero-sized geom
+    makes the model fail to compile. Conversion must continue without the mass properties.
+-->
+<mujoco model="mass_bake_uncompilable">
+    <worldbody>
+        <body name="uncompilable">
+            <geom type="box" name="visual" size="0.1 0.1 0.1" contype="0" conaffinity="0" mass="1.0"/>
+            <geom type="box" name="degenerate" size="0 0.1 0.1" contype="1" conaffinity="1" mass="2.0"/>
+        </body>
+    </worldbody>
+</mujoco>

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -126,6 +126,37 @@ class TestBodies(ConverterTestCase):
         self.assertTrue(gravcomp_prim.HasAPI(UsdPhysics.RigidBodyAPI))
         self.assertAlmostEqual(gravcomp_prim.GetAttribute("mjc:body:gravcomp").Get(), 0.2)
 
+    def test_mass_baked_when_a_visual_provides_it(self):
+        """A body whose mass depends on a non-colliding geom carries explicit mass properties.
+
+        MuJoCo infers body mass from every geom in ``inertiagrouprange``, including geoms that
+        collide with nothing. USD accumulates mass only from enabled colliders, so that
+        contribution would be lost; the compiled values are authored on the body instead.
+        """
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/mass_from_visual")
+        self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
+        mass_api = UsdPhysics.MassAPI(prim)
+        # 3.0 from the visual geom plus 1.0 from the collider.
+        self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 4.0, places=5)
+        self.assertTrue(mass_api.GetDiagonalInertiaAttr().HasAuthoredValue())
+
+        # The visual itself is plain geometry: no collider, no mass.
+        visual = self.stage.GetPrimAtPath("/bodies/Geometry/mass_from_visual/geom_0")
+        if visual.IsValid():
+            self.assertFalse(visual.HasAPI(UsdPhysics.CollisionAPI))
+            self.assertFalse(visual.HasAPI(UsdPhysics.MassAPI))
+
+    def test_mass_not_baked_when_only_colliders_provide_it(self):
+        """A body whose mass comes solely from colliders is left to USD accumulation.
+
+        The colliders carry the authored mass, so a reader can aggregate it. Baking here would
+        replace the source's per-geom description with a compiled number and override the
+        author's intent to leave the mass implicit.
+        """
+        prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/mass_from_colliders")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+
     def test_zero_inertia(self):
         zero_inertia_prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/zero_inertia")
         self.assertTrue(zero_inertia_prim.HasAPI(UsdPhysics.RigidBodyAPI))

--- a/tests/testBodies.py
+++ b/tests/testBodies.py
@@ -4,9 +4,13 @@ import pathlib
 
 import mujoco
 import numpy as np
-from pxr import Gf, Sdf, Usd, UsdPhysics
+import usdex.core
+import usdex.test
+from pxr import Gf, Sdf, Tf, Usd, UsdGeom, UsdPhysics
 
 import mujoco_usd_converter
+from mujoco_usd_converter._impl.body import bake_body_mass, get_model_body_id
+from mujoco_usd_converter._impl.data import ConversionData
 from tests.util.ConverterTestCase import ConverterTestCase
 
 
@@ -155,6 +159,88 @@ class TestBodies(ConverterTestCase):
         """
         prim: Usd.Prim = self.stage.GetPrimAtPath("/bodies/Geometry/mass_from_colliders")
         self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+
+    def test_mass_baked_onto_the_right_body_through_attach(self):
+        """Bake each body's own mass when attaching has shifted the compiled body ids.
+
+        Attaching splices the attached subtree into the body tree, so a body after the attach
+        point no longer compiles to the id its authored position among its siblings suggests.
+        Every body in the fixture carries a distinct mass, so a lookup that misidentified the
+        compiled body would bake a wrong number rather than fail outright.
+        """
+        model = pathlib.Path("./tests/data/mass_bake_attach.xml")
+        # a directory of its own, so this asset does not overwrite the payload of the one in setUp
+        asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir(model.stem))
+        stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+
+        # 5.0 from the attached body's visual geom plus 1.0 from its collider
+        attached: Usd.Prim = stage.GetPrimAtPath("/mass_bake_attach/Geometry/before/attached_visual_mass")
+        self.assertTrue(attached.HasAPI(UsdPhysics.MassAPI))
+        self.assertAlmostEqual(UsdPhysics.MassAPI(attached).GetMassAttr().Get(), 6.0, places=5)
+
+        # 9.0 from a visual geom plus 1.0 from a collider, two ids further along than authored
+        after: Usd.Prim = stage.GetPrimAtPath("/mass_bake_attach/Geometry/after")
+        self.assertTrue(after.HasAPI(UsdPhysics.MassAPI))
+        self.assertAlmostEqual(UsdPhysics.MassAPI(after).GetMassAttr().Get(), 10.0, places=5)
+
+        for path in ("before", "before/attached_visual_mass/attached_nested"):
+            prim: Usd.Prim = stage.GetPrimAtPath(f"/mass_bake_attach/Geometry/{path}")
+            self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+            self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+
+    def test_mass_not_baked_when_the_model_cannot_compile(self):
+        """Warn and carry on when a body needs its mass baked but the model will not compile.
+
+        Baking reads compiled values, which not every parsable MJCF can produce. Nothing else in
+        the conversion depends on them, so the asset is still written, without mass properties.
+        """
+        model = pathlib.Path("./tests/data/mass_bake_uncompilable.xml")
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Unable to compile the model to bake mass for body 'uncompilable'.*")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir(model.stem))
+
+        stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+        prim: Usd.Prim = stage.GetPrimAtPath("/mass_bake_uncompilable/Geometry/uncompilable")
+        self.assertTrue(prim.HasAPI(UsdPhysics.RigidBodyAPI))
+        self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+
+    def test_mass_not_baked_for_a_body_outside_the_converted_spec(self):
+        """Warn rather than bake when the spec being converted does not contain the body.
+
+        The lookup is positional, so a body it cannot place has to be reported rather than
+        resolved to whichever body happens to occupy that position.
+        """
+        spec = mujoco.MjSpec.from_string("<mujoco><worldbody><body name='a'/></worldbody></mujoco>")
+        other = mujoco.MjSpec.from_string("<mujoco><worldbody><body name='b'/></worldbody></mujoco>")
+        data = ConversionData(
+            spec=spec,
+            model=None,
+            content={},
+            libraries={},
+            references={},
+            geom_targets={},
+            name_cache=usdex.core.NameCache(),
+            scene=False,
+            comment="",
+        )
+        compiled = data.get_model()
+        self.assertEqual(get_model_body_id(spec.body("a"), compiled, data), 1)
+        self.assertIsNone(get_model_body_id(other.body("b"), compiled, data))
+
+        stage: Usd.Stage = Usd.Stage.CreateInMemory()
+        prim: Usd.Prim = UsdGeom.Xform.Define(stage, "/body").GetPrim()
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Unable to locate body 'b' in the compiled model.*")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            bake_body_mass(other.body("b"), prim, data)
         self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
 
     def test_zero_inertia(self):

--- a/tests/testGeom.py
+++ b/tests/testGeom.py
@@ -87,8 +87,8 @@ class TestGeom(ConverterTestCase):
         self.assertEqual(visual_prim.GetAttribute("mjc:group").Get(), 1)
 
         guide_prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/guide_visual")
-        self.assertFalse(guide_prim.HasAPI("MjcImageableAPI"))
-        self.assertTrue(guide_prim.HasAPI("MjcCollisionAPI"))
+        self.assertTrue(guide_prim.HasAPI("MjcImageableAPI"))
+        self.assertFalse(guide_prim.HasAPI("MjcCollisionAPI"))
         self.assertEqual(guide_prim.GetAttribute("mjc:group").Get(), 3)
 
         guide_mesh_collider_prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/guide_mesh_collider")
@@ -116,48 +116,27 @@ class TestGeom(ConverterTestCase):
         self.assertFalse(prim.HasAPI("NewtonCollisionAPI"))
         self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), UsdGeom.Tokens.default_)
 
-    def test_visual_with_mass(self):
-        prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/visual_with_mass")
-        self.assertTrue(prim.HasAPI(UsdPhysics.CollisionAPI))
-        collider_api = UsdPhysics.CollisionAPI(prim)
-        self.assertFalse(collider_api.GetCollisionEnabledAttr().Get())
-        self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
-        mass_api = UsdPhysics.MassAPI(prim)
-        self.assertAlmostEqual(mass_api.GetMassAttr().Get(), 5.0)
-        # Density is NOT authored when mass is specified (mass XOR density)
-        self.assertFalse(mass_api.GetDensityAttr().HasAuthoredValue())
-        self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), UsdGeom.Tokens.default_)
+    def test_visual_geoms_are_not_colliders(self):
+        """A geom that collides with nothing is authored as pure visual, whatever mass it carries.
 
-    def test_visual_with_density(self):
-        prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/visual_with_density")
-        self.assertTrue(prim.HasAPI(UsdPhysics.CollisionAPI))
-        collider_api = UsdPhysics.CollisionAPI(prim)
-        self.assertFalse(collider_api.GetCollisionEnabledAttr().Get())
-        self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
-        mass_api = UsdPhysics.MassAPI(prim)
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 2000)
-        self.assertFalse(mass_api.GetMassAttr().HasAuthoredValue())
-        self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), UsdGeom.Tokens.default_)
-
-    def test_visual_in_range_no_mass(self):
-        prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/visual_in_range_no_mass")
-        collider_api = UsdPhysics.CollisionAPI(prim)
-        self.assertFalse(collider_api.GetCollisionEnabledAttr().Get())
-        self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
-        mass_api = UsdPhysics.MassAPI(prim)
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 1000)
-        self.assertFalse(mass_api.GetMassAttr().HasAuthoredValue())
-        self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), UsdGeom.Tokens.default_)
-
-    def test_guide_visual(self):
-        prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/guide_visual")
-        collider_api = UsdPhysics.CollisionAPI(prim)
-        self.assertFalse(collider_api.GetCollisionEnabledAttr().Get())
-        self.assertTrue(prim.HasAPI(UsdPhysics.MassAPI))
-        mass_api = UsdPhysics.MassAPI(prim)
-        self.assertAlmostEqual(mass_api.GetDensityAttr().Get(), 1000)
-        self.assertFalse(mass_api.GetMassAttr().HasAuthoredValue())
-        self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), UsdGeom.Tokens.guide)
+        MuJoCo lets such a geom contribute to its body's mass. USD has no way to express that
+        -- a disabled collider contributes nothing (OpenUSD PR 4164) and mass on a prim that is
+        neither body nor collider is never accumulated -- so the mass moves to the body and the
+        geom is left as plain geometry.
+        """
+        for name, purpose in (
+            ("visual_with_mass", UsdGeom.Tokens.default_),
+            ("visual_with_density", UsdGeom.Tokens.default_),
+            ("visual_in_range_no_mass", UsdGeom.Tokens.default_),
+            ("guide_visual", UsdGeom.Tokens.guide),
+        ):
+            with self.subTest(geom=name):
+                prim: Usd.Prim = self.stage.GetPrimAtPath(f"/geoms/Geometry/geom_body/{name}")
+                self.assertTrue(prim.IsValid())
+                self.assertFalse(prim.HasAPI(UsdPhysics.CollisionAPI))
+                self.assertFalse(prim.HasAPI("NewtonCollisionAPI"))
+                self.assertFalse(prim.HasAPI(UsdPhysics.MassAPI))
+                self.assertEqual(UsdGeom.Imageable(prim).GetPurposeAttr().Get(), purpose)
 
     def test_mesh_collider(self):
         prim: Usd.Prim = self.stage.GetPrimAtPath("/geoms/Geometry/geom_body/guide_mesh_collider")

--- a/tests/testGeomFitting.py
+++ b/tests/testGeomFitting.py
@@ -17,7 +17,7 @@ class TestGeomFitting(ConverterTestCase):
         with usdex.test.ScopedDiagnosticChecker(
             self,
             [
-                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Parent body name not found.*"),
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, r"Parent body name not found \(geom id: 1\)"),
                 (Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'ellipsoid'"),
             ],
             level=usdex.core.DiagnosticsLevel.eWarning,

--- a/tests/testGeomFittingAABB.py
+++ b/tests/testGeomFittingAABB.py
@@ -17,7 +17,7 @@ class TestGeomFittingAABB(ConverterTestCase):
         with usdex.test.ScopedDiagnosticChecker(
             self,
             [
-                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Parent body name not found.*"),
+                (Tf.TF_DIAGNOSTIC_WARNING_TYPE, r"Parent body name not found \(geom id: 1\)"),
                 (Tf.TF_DIAGNOSTIC_WARNING_TYPE, "Unsupported or unknown geom type mjtGeom.mjGEOM_ELLIPSOID for geom 'ellipsoid'"),
             ],
             level=usdex.core.DiagnosticsLevel.eWarning,


### PR DESCRIPTION
## Description

A MuJoCo geom that collides with nothing can still contribute to its body's mass. The converter carried those as *disabled colliders*, so that USD mass aggregation would pick the mass up.

That does not hold. A disabled collider contributes nothing to its body's mass properties (see [OpenUSD PR 4164](https://github.com/PixarAnimationStudios/OpenUSD/pull/4164)), and USD accumulates mass only from bodies and colliders — mass authored on a prim that is neither is never accumulated, however it is expressed. So the contribution was being silently dropped.

Two changes:

- **Author non-colliding geoms as plain visuals.** The disabled-collider form no longer carries meaning, so it is not emitted.
- **Author MuJoCo's compiled mass, centre of mass and inertia on the owning body** when that body's mass depends on such a geom. The body prim is the only place USD can hold it.

Fixes #100.

### Deliberate scope: only bake what USD cannot express

Bodies whose mass comes *solely from colliders* are left exactly as they are. Their mass is already described the way the source expressed it — explicitly, or implicitly through density and volume — and USD can carry that faithfully.

A reader that computes a different volume than MuJoCo for the same mesh will get a different mass, and that is not this converter's to resolve. The goal here is a faithful reflection of what the content author expressed, not a reproduction of MuJoCo's compiled numbers. An author who wants an identical mass in every engine can say so explicitly in the source, which is exactly what MuJoCo's own `compiler saveinertial` is for.

So the bake fires only where the alternative is losing information outright.

### Cost

The bake needs MuJoCo's compiled values, and the compile is deferred behind the check above — a model that needs no bake is never compiled on its account. Measured on a synthetic pair: 0 `MjSpec.compile()` calls for a collider-only model, 1 where a visual carries mass.

The first commit is a prerequisite: `MjSpec.compile()` mutates the spec it is called on, and conversion reads from that spec throughout, so the lazy compile now runs against a copy. Mesh fitting was the only existing caller and shares the same cached model, so no model compiles twice.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).

## Test plan

```
uv run python -m unittest discover -s ./tests   # 178 tests
```

Body masses after conversion, read back through Newton's `ModelBuilder.add_usd()` and compared against `mjModel.body_mass`:

| model | bodies diverging >0.1% | total (MuJoCo) | total (via USD) |
| --- | --- | --- | --- |
| Menagerie SO-101 | 0 | 0.64401 | 0.64401 |
| Menagerie Wonik Allegro | 0 | 0.64656 | 0.64656 |

New tests cover both sides of the decision: `mass_from_visual` is baked, and `mass_from_colliders` is deliberately left without a body-level `MassAPI`. The existing visual-geom tests are updated to the new contract, since they asserted the disabled-collider form.

No changelog entry, per the release-prep workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
