### PR TITLE
Author static friction alongside dynamic friction

### DIFF
--- a/mujoco_usd_converter/_impl/geom.py
+++ b/mujoco_usd_converter/_impl/geom.py
@@ -389,7 +389,15 @@ def create_physics_material(physics_materials: Usd.Prim, geom: mujoco.MjsGeom, d
     ke, kd = solref_to_stiffness_damping(geom.solref)
 
     name = data.name_cache.getPrimName(physics_materials, "PhysicsMaterial")
-    material: UsdShade.Material = usdex.core.definePhysicsMaterial(physics_materials, name, dynamicFriction=sliding_friction)
+    # MuJoCo has a single sliding friction coefficient, applied whether a contact is stuck or
+    # slipping, so both UsdPhysics coefficients take it. Leaving physics:staticFriction unauthored
+    # would not leave it unspecified: its schema fallback is 0.0, which no MuJoCo model means.
+    material: UsdShade.Material = usdex.core.definePhysicsMaterial(
+        physics_materials,
+        name,
+        dynamicFriction=sliding_friction,
+        staticFriction=sliding_friction,
+    )
 
     material.GetPrim().ApplyAPI("NewtonMaterialAPI")
     set_schema_attribute(material.GetPrim(), "newton:torsionalFriction", torsional_friction)

--- a/tests/testPhysicsMaterials.py
+++ b/tests/testPhysicsMaterials.py
@@ -60,6 +60,7 @@ class TestPhysicsMaterials(ConverterTestCase):
             set(phys_mat_1.GetPrim().GetAuthoredPropertyNames()),
             {
                 "physics:dynamicFriction",
+                "physics:staticFriction",
                 "newton:rollingFriction",
                 "newton:torsionalFriction",
                 "newton:contactStiffness",
@@ -67,6 +68,8 @@ class TestPhysicsMaterials(ConverterTestCase):
             },
         )
         self.assertAlmostEqual(phys_mat_1.GetDynamicFrictionAttr().Get(), 0.8)
+        # MuJoCo's single sliding coefficient applies stuck or slipping, so both USD coefficients take it
+        self.assertAlmostEqual(phys_mat_1.GetStaticFrictionAttr().Get(), 0.8)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:torsionalFriction").Get(), 0.1)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:rollingFriction").Get(), 0.05)
         self.assertAlmostEqual(phys_mat_1.GetPrim().GetAttribute("newton:contactStiffness").Get(), 2500.0)
@@ -92,6 +95,9 @@ class TestPhysicsMaterials(ConverterTestCase):
         self.assertTrue(default_friction_material_prim.HasAPI("PhysicsMaterialAPI"))
         self.assertFalse(default_friction_material_prim.GetAttribute("dynamicFriction").HasAuthoredValue())
         self.assertAlmostEqual(default_friction_material_prim.GetAttribute("physics:dynamicFriction").Get(), 1.0)
+        # authored rather than left to the 0.0 schema fallback, which would mean frictionless from rest
+        self.assertTrue(default_friction_material_prim.GetAttribute("physics:staticFriction").HasAuthoredValue())
+        self.assertAlmostEqual(default_friction_material_prim.GetAttribute("physics:staticFriction").Get(), 1.0)
 
         # Assert direct-mode solref (both negative) produces correct ke/kd
         direct_prim = stage.GetPrimAtPath("/physics_materials/Geometry/direct_solref")


### PR DESCRIPTION
## Description

Author `physics:staticFriction` from MuJoCo's sliding friction coefficient, alongside the `physics:dynamicFriction` we already authored.

MuJoCo has exactly one contact friction coefficient. `geom/friction[0]` is [the sliding friction](https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-geom-friction), and it is the µ bounding tangential force in the friction cone (`f₁² ≥ Σᵢ fᵢ²/µᵢ²`, [Computation § Contact](https://mujoco.readthedocs.io/en/stable/computation/index.html#coneline)) whether the contact is stuck or slipping. There is no separate break-away coefficient. `UsdPhysics` splits that into two attributes, so both take the same value.

The reason to author it rather than leave it alone: **omitting `physics:staticFriction` does not leave it unspecified.** Its schema fallback is `0.0`:

```python
>>> UsdPhysics.MaterialAPI.Apply(prim).CreateStaticFrictionAttr().Get()
0.0
```

So converted assets were telling any reader that honours UsdPhysics fallbacks that the material resists nothing from rest — which no MuJoCo model means. Authoring both from the single coefficient is the faithful translation, and equal coefficients are also exactly how a reader that *does* model stiction is told there is none, matching MuJoCo's behaviour.

One thing worth stating explicitly, because it invites confusion: this is unrelated to MuJoCo's `frictionloss`, which [the docs also call "static friction"](https://mujoco.readthedocs.io/en/stable/computation/index.html) ("also known as dry friction, or static friction, or load-independent friction"). That is joint and tendon dry friction, a different mechanism, and it is already authored separately as `mjc:frictionloss`. It should not be mapped to `physics:staticFriction`.

Material de-duplication is unaffected — `hash_physics_material` keys on the sliding coefficient, and static friction is derived from it, so no new value enters the hash.

Reported on newton-physics/newton-assets#38, where a reviewer noticed the missing attribute on published assets. Note those particular assets come from the Isaac Sim asset bucket rather than this converter, so they need a separate fix; this PR stops the converter producing the same gap.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).

## Test plan

```
python -m unittest discover -s ./tests   # 179 tests, OK
poe lint                                 # all passed
```

`testPhysicsMaterials` pins the authored property set, so it failed before the change with `Items in the first set but not the second: 'physics:staticFriction'`. It now also asserts static equals dynamic on a custom material (0.8) and that the attribute is authored rather than left to the fallback on a default-friction material (1.0).

Converted output, confirming every material carries both:

```
PhysicsMaterial      static=0.8  dynamic=0.8
PhysicsMaterial_1    static=0.5  dynamic=0.5
PhysicsMaterial_2    static=1.0  dynamic=1.0
PhysicsMaterial_3    static=1.0  dynamic=1.0
PhysicsMaterial_4    static=0.3  dynamic=0.3
```
