### PR TITLE
Author limit gains in NewtonJointAPI's effort space

### DIFF
--- a/mujoco_usd_converter/_impl/joint.py
+++ b/mujoco_usd_converter/_impl/joint.py
@@ -67,10 +67,10 @@ def convert_joints(parent: Usd.Prim, body: mujoco.MjsBody, data: ConversionData)
 
         data.references[Tokens.PhysicsJoints][joint.name] = joint_prim.GetPrim()
 
-        apply_mjc_joint_api(joint_prim.GetPrim(), joint, limits[0] is not None and limits[1] is not None)
+        apply_mjc_joint_api(joint_prim.GetPrim(), joint, limits[0] is not None and limits[1] is not None, data)
 
 
-def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited: bool):
+def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited: bool, data: ConversionData):
     prim.ApplyAPI("MjcJointAPI")
     prim.ApplyAPI("NewtonJointAPI")
 
@@ -97,7 +97,7 @@ def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited
     set_schema_attribute(prim, "newton:damping", to_newton_angular_gain(joint, joint.damping[0]))
     set_schema_attribute(prim, "newton:friction", joint.frictionloss)
     if is_joint_limited:
-        limit_stiffness, limit_damping = get_newton_limit_stiffness_damping(joint)
+        limit_stiffness, limit_damping = get_newton_limit_stiffness_damping(joint, get_limit_force_scale(joint, data))
         if limit_stiffness is not None:
             set_schema_attribute(prim, "newton:limitStiffness", limit_stiffness)
         if limit_damping is not None:
@@ -115,7 +115,45 @@ def to_newton_angular_gain(joint: mujoco.MjsJoint, value: float) -> float:
     return value
 
 
-def get_newton_limit_stiffness_damping(joint: mujoco.MjsJoint) -> tuple[float | None, float | None]:
+def get_limit_force_scale(joint: mujoco.MjsJoint, data: ConversionData) -> float:
+    """Compute the factor relating a normalized limit gain to its effort-space equivalent.
+
+    MuJoCo's `solreflimit` describes the limit constraint in normalized (acceleration)
+    units, so the effort it produces depends on the constraint's effective inertia.
+    `NewtonJointAPI` instead defines `effort = limitStiffness * penetration`, so the two
+    differ by that inertia, which MuJoCo exposes as the DOF's `invweight0` narrowed by the
+    impedance width `solimp[1]`.
+
+    Returns 1.0 when the joint has no compiled counterpart, or when MuJoCo itself would
+    not narrow the constraint, matching how the values are consumed downstream.
+    """
+    model = data.get_model()
+    joint_id = _get_compiled_joint_id(joint, data)
+    if joint_id < 0:
+        return 1.0
+    invweight = float(model.dof_invweight0[model.jnt_dofadr[joint_id]])
+    dmax = float(model.jnt_solimp[joint_id][1])
+    if invweight > 0.0 and dmax < 1.0:
+        return invweight * (1.0 - dmax)
+    return 1.0
+
+
+def _get_compiled_joint_id(joint: mujoco.MjsJoint, data: ConversionData) -> int:
+    """Resolve a spec joint's id in the compiled model.
+
+    `MjsJoint.id` stays unset because conversion compiles a copy of the spec, so named
+    joints resolve through the model while unnamed ones fall back to their position in
+    the spec, which the compiler preserves.
+    """
+    if joint.name:
+        return mujoco.mj_name2id(data.get_model(), mujoco.mjtObj.mjOBJ_JOINT, joint.name)
+    try:
+        return list(data.spec.joints).index(joint)
+    except ValueError:
+        return -1
+
+
+def get_newton_limit_stiffness_damping(joint: mujoco.MjsJoint, force_scale: float) -> tuple[float | None, float | None]:
     timeconst = joint.solref_limit[0]
     dampratio = joint.solref_limit[1]
 
@@ -127,6 +165,11 @@ def get_newton_limit_stiffness_damping(joint: mujoco.MjsJoint) -> tuple[float | 
             return None, None
         stiffness = 1.0 / (timeconst * timeconst * dampratio * dampratio)
         damping = 2.0 / timeconst
+
+    # Both gains are normalized by the constraint's effective inertia, so undo that to
+    # reach the effort space NewtonJointAPI defines. See get_limit_force_scale.
+    stiffness /= force_scale
+    damping /= force_scale
 
     # NewtonJointAPI angular limit stiffness/damping are authored per degree.
     return to_newton_angular_gain(joint, stiffness), to_newton_angular_gain(joint, damping)

--- a/tests/data/joint_limit_gains.xml
+++ b/tests/data/joint_limit_gains.xml
@@ -1,0 +1,14 @@
+<mujoco model="joint_limit_gains">
+  <compiler angle="radian"/>
+  <worldbody>
+    <body name="body1" pos="0 0 0.5">
+      <geom type="box" size="0.05 0.05 0.5"/>
+      <joint name="hinge_joint" type="hinge" axis="1 0 0" range="-0.5 0.5" limited="true" solreflimit="0.02 1"/>
+    </body>
+
+    <body name="body2" pos="0 1 0.5">
+      <geom type="box" size="0.05 0.05 0.5"/>
+      <joint name="slide_joint" type="slide" axis="0 1 0" range="-0.5 0.5" limited="true" solreflimit="0.04 0.5"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/tests/testEqualities.py
+++ b/tests/testEqualities.py
@@ -381,8 +381,11 @@ class TestEqualities(ConverterTestCase):
         self.assertEqual(len(targets), 1)
         self.assertEqual("/equality_joint_attributes/Geometry/body2/body3/slide1", str(targets[0]))
         self.assertTrue(default_joint.GetAttribute("newton:mimicEnabled").Get())
-        self.assertAlmostEqual(default_joint.GetAttribute("newton:limitStiffness").Get(), 2500)
-        self.assertAlmostEqual(default_joint.GetAttribute("newton:limitDamping").Get(), 100)
+        # The limit gains are lifted out of MuJoCo's normalized space into the effort
+        # space NewtonJointAPI defines, so they carry the constraint's effective inertia.
+        slide0_scale = self.limitForceScale(model, "slide0")
+        self.assertAlmostEqual(default_joint.GetAttribute("newton:limitStiffness").Get(), 2500 / slide0_scale)
+        self.assertAlmostEqual(default_joint.GetAttribute("newton:limitDamping").Get(), 100 / slide0_scale)
 
         # Check that only required relationships and Newton joint values whose schema defaults differ are authored.
         # mimicCoef0 is authored here because the fixture gives the slide follower a

--- a/tests/testJoints.py
+++ b/tests/testJoints.py
@@ -22,35 +22,75 @@ class TestJoints(ConverterTestCase):
             joint.solref_limit = solref_limit
             return joint
 
+        # A force scale of 1 isolates the solref conversion itself; the effective-inertia
+        # scale is covered by test_newton_limit_gains_are_in_effort_space.
         # Standard positive solref mode:
         #   stiffness = 1 / (timeconst^2 * dampratio^2)
         #   damping = 2 / timeconst
         linear_joint = add_joint("linear_joint", mujoco.mjtJoint.mjJNT_SLIDE, [0.04, 0.5])
-        stiffness, damping = get_newton_limit_stiffness_damping(linear_joint)
+        stiffness, damping = get_newton_limit_stiffness_damping(linear_joint, 1.0)
         self.assertAlmostEqual(stiffness, 2500.0)
         self.assertAlmostEqual(damping, 50.0)
 
         # Hinge/ball limit gains are authored in USD's per-degree angular units.
         hinge_joint = add_joint("hinge_joint", mujoco.mjtJoint.mjJNT_HINGE, [0.04, 0.5])
-        stiffness, damping = get_newton_limit_stiffness_damping(hinge_joint)
+        stiffness, damping = get_newton_limit_stiffness_damping(hinge_joint, 1.0)
         self.assertAlmostEqual(stiffness, 2500.0 * math.pi / 180.0)
         self.assertAlmostEqual(damping, 50.0 * math.pi / 180.0)
 
         ball_joint = add_joint("ball_joint", mujoco.mjtJoint.mjJNT_BALL, [0.04, 0.5])
-        stiffness, damping = get_newton_limit_stiffness_damping(ball_joint)
+        stiffness, damping = get_newton_limit_stiffness_damping(ball_joint, 1.0)
         self.assertAlmostEqual(stiffness, 2500.0 * math.pi / 180.0)
         self.assertAlmostEqual(damping, 50.0 * math.pi / 180.0)
 
         # Direct negative solref mode encodes (-stiffness, -damping).
         direct_joint = add_joint("direct_joint", mujoco.mjtJoint.mjJNT_SLIDE, [-12.0, -3.0])
-        stiffness, damping = get_newton_limit_stiffness_damping(direct_joint)
+        stiffness, damping = get_newton_limit_stiffness_damping(direct_joint, 1.0)
         self.assertAlmostEqual(stiffness, 12.0)
         self.assertAlmostEqual(damping, 3.0)
 
         # Invalid mixed-sign or zero values are not converted.
         for index, solref_limit in enumerate(([0.0, 1.0], [0.04, 0.0], [-12.0, 3.0], [12.0, -3.0])):
             joint = add_joint(f"invalid_joint_{index}", mujoco.mjtJoint.mjJNT_SLIDE, solref_limit)
-            self.assertEqual(get_newton_limit_stiffness_damping(joint), (None, None))
+            self.assertEqual(get_newton_limit_stiffness_damping(joint, 1.0), (None, None))
+
+    def test_newton_limit_gains_are_in_effort_space(self):
+        # NewtonJointAPI defines effort = limitStiffness * penetration, while MuJoCo's
+        # solreflimit describes the same limit in normalized units. The two differ by the
+        # constraint's effective inertia, so a consumer that undoes the normalization must
+        # recover the authored solreflimit from what we write.
+        model = pathlib.Path("./tests/data/joint_limit_gains.xml")
+        asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir())
+        stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(stage)
+
+        compiled = mujoco.MjSpec.from_file(str(model)).compile()
+
+        for body, name, solreflimit, per_degree in (
+            ("body1", "hinge_joint", (0.02, 1.0), True),
+            ("body2", "slide_joint", (0.04, 0.5), False),
+        ):
+            with self.subTest(joint=name):
+                prim: Usd.Prim = stage.GetPrimAtPath(f"/joint_limit_gains/Geometry/{body}/{name}")
+                self.assertTrue(prim.IsValid())
+
+                stiffness = prim.GetAttribute("newton:limitStiffness").Get()
+                damping = prim.GetAttribute("newton:limitDamping").Get()
+                # the MJC attribute retains the authored normalized value
+                self.assertEqual(tuple(prim.GetAttribute("mjc:solreflimit").Get()), solreflimit)
+
+                if per_degree:
+                    stiffness /= math.pi / 180.0
+                    damping /= math.pi / 180.0
+
+                joint_id = mujoco.mj_name2id(compiled, mujoco.mjtObj.mjOBJ_JOINT, name)
+                scale = compiled.dof_invweight0[compiled.jnt_dofadr[joint_id]] * (1.0 - compiled.jnt_solimp[joint_id][1])
+                self.assertGreater(scale, 0.0)
+
+                # Undo the normalization the way a solver consuming effort-space gains would.
+                timeconst, dampratio = solreflimit
+                self.assertAlmostEqual(stiffness * scale, 1.0 / (timeconst**2 * dampratio**2), places=4)
+                self.assertAlmostEqual(damping * scale, 2.0 / timeconst, places=4)
 
     def test_newton_damping_is_per_degree(self):
         # MuJoCo authors joint damping per radian, but NewtonJointAPI authors it per degree,
@@ -449,28 +489,31 @@ class TestJoints(ConverterTestCase):
         self.assertFalse(unlimited_joint.GetLowerLimitAttr().HasAuthoredValue())
         self.assertFalse(unlimited_joint.GetUpperLimitAttr().HasAuthoredValue())
 
-        # Direct-mode solreflimit encodes stiffness and damping directly, then
-        # angular joints are authored in the per-degree units expected by USD.
+        # Direct-mode solreflimit encodes stiffness and damping directly. Both are lifted
+        # out of MuJoCo's normalized space into the effort space NewtonJointAPI defines,
+        # then angular joints are authored in the per-degree units expected by USD.
+        scale = self.limitForceScale(model, "direct_limit_joint")
         direct_limit_joint = UsdPhysics.RevoluteJoint(stage.GetPrimAtPath("/joint_limits_no_autolimits/Geometry/body5/body6/direct_limit_joint"))
         self.assertTrue(direct_limit_joint.GetLowerLimitAttr().HasAuthoredValue())
         self.assertAlmostEqual(direct_limit_joint.GetLowerLimitAttr().Get(), -20)
         self.assertAlmostEqual(direct_limit_joint.GetUpperLimitAttr().Get(), 20)
         direct_limit_prim = direct_limit_joint.GetPrim()
         self.assertTrue(direct_limit_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
-        self.assertAlmostEqual(direct_limit_prim.GetAttribute("newton:limitStiffness").Get(), 12 * math.pi / 180.0)
+        self.assertAlmostEqual(direct_limit_prim.GetAttribute("newton:limitStiffness").Get(), 12 / scale * math.pi / 180.0)
         self.assertTrue(direct_limit_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
-        self.assertAlmostEqual(direct_limit_prim.GetAttribute("newton:limitDamping").Get(), 3 * math.pi / 180.0)
+        self.assertAlmostEqual(direct_limit_prim.GetAttribute("newton:limitDamping").Get(), 3 / scale * math.pi / 180.0)
 
-        # Prismatic joints use the raw linear stiffness/damping conversion.
+        # Prismatic joints skip the per-degree conversion but still carry the inertia scale.
+        linear_scale = self.limitForceScale(model, "linear_limit_joint")
         linear_limit_joint = UsdPhysics.PrismaticJoint(stage.GetPrimAtPath("/joint_limits_no_autolimits/Geometry/body7/body8/linear_limit_joint"))
         self.assertTrue(linear_limit_joint.GetLowerLimitAttr().HasAuthoredValue())
         self.assertAlmostEqual(linear_limit_joint.GetLowerLimitAttr().Get(), -0.2)
         self.assertAlmostEqual(linear_limit_joint.GetUpperLimitAttr().Get(), 0.4)
         linear_limit_prim = linear_limit_joint.GetPrim()
         self.assertTrue(linear_limit_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
-        self.assertAlmostEqual(linear_limit_prim.GetAttribute("newton:limitStiffness").Get(), 2500)
+        self.assertAlmostEqual(linear_limit_prim.GetAttribute("newton:limitStiffness").Get(), 2500 / linear_scale)
         self.assertTrue(linear_limit_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
-        self.assertAlmostEqual(linear_limit_prim.GetAttribute("newton:limitDamping").Get(), 50)
+        self.assertAlmostEqual(linear_limit_prim.GetAttribute("newton:limitDamping").Get(), 50 / linear_scale)
 
     def test_mjc_schema(self):
         # Test that all joint attributes are authored correctly
@@ -547,9 +590,10 @@ class TestJoints(ConverterTestCase):
         self.assertAlmostEqual(custom_joint.GetAttribute("newton:friction").Get(), 0.2)
         self.assertFalse(custom_joint.GetAttribute("newton:velocityLimit").HasAuthoredValue())
         self.assertTrue(custom_joint.GetAttribute("newton:limitStiffness").HasAuthoredValue())
-        self.assertAlmostEqual(custom_joint.GetAttribute("newton:limitStiffness").Get(), 40000 * math.pi / 180.0, places=4)
+        custom_scale = self.limitForceScale(model, "custom_joint")
+        self.assertAlmostEqual(custom_joint.GetAttribute("newton:limitStiffness").Get(), 40000 / custom_scale * math.pi / 180.0, places=3)
         self.assertTrue(custom_joint.GetAttribute("newton:limitDamping").HasAuthoredValue())
-        self.assertAlmostEqual(custom_joint.GetAttribute("newton:limitDamping").Get(), 200 * math.pi / 180.0, places=4)
+        self.assertAlmostEqual(custom_joint.GetAttribute("newton:limitDamping").Get(), 200 / custom_scale * math.pi / 180.0, places=4)
 
         # A joint with explicitly authored default values in MJC does not need to author any values in USD
         default_joint: Usd.Prim = stage.GetPrimAtPath("/joint_attributes/Geometry/body2/default_joint")

--- a/tests/util/ConverterTestCase.py
+++ b/tests/util/ConverterTestCase.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import mujoco
 import omni.asset_validator
 import usdex.core
 import usdex.test
@@ -17,3 +18,16 @@ class ConverterTestCase(usdex.test.TestCase):
         # All conversion results should be valid atomic assets
         self.validationEngine.enable_rule(omni.asset_validator.AnchoredAssetPathsChecker)
         self.validationEngine.enable_rule(omni.asset_validator.SupportedFileTypesChecker)
+
+    def limitForceScale(self, model: str, joint_name: str) -> float:  # noqa: N802
+        """Compute the factor between a joint's normalized and effort-space limit gains.
+
+        Mirrors `joint.get_limit_force_scale` from the compiled model so tests can state
+        an expectation in the normalized units the MJCF authors, rather than restating
+        the inertia-dependent product as a literal.
+        """
+        compiled = mujoco.MjSpec.from_file(str(model)).compile()
+        joint_id = mujoco.mj_name2id(compiled, mujoco.mjtObj.mjOBJ_JOINT, joint_name)
+        invweight = float(compiled.dof_invweight0[compiled.jnt_dofadr[joint_id]])
+        dmax = float(compiled.jnt_solimp[joint_id][1])
+        return invweight * (1.0 - dmax) if invweight > 0.0 and dmax < 1.0 else 1.0


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft, pending resolution of [newton-physics/newton#3762](https://github.com/newton-physics/newton/issues/3762).**
> This implements one of the two possible resolutions to that issue — the one that takes `NewtonJointAPI`'s documented units as authoritative. If Newton concludes that `newton:limitStiffness` is meant to carry MuJoCo's normalized magnitude instead, this PR should be closed and the schema documentation corrected instead. Not for merge until that is settled.

## Description

MuJoCo's `solreflimit` describes the limit constraint in normalized (acceleration) units, so the effort it produces depends on the constraint's effective inertia. `NewtonJointAPI` instead defines:

> `effort = limitStiffness * penetration` … Units: effort / degrees (angular DOFs)

`get_newton_limit_stiffness_damping()` converted `solreflimit` with only the per-degree scaling, so the authored value carried MuJoCo's normalized magnitude in an attribute documented as effort per degree. For the default `solreflimit = (0.02, 1)` we wrote `1 / (0.02² · 1²) = 2500`, which has units of s⁻², not torque per radian.

A consumer that undoes the normalization therefore recovers a different solref than the source MJCF. Loading a converted Apptronik Apollo into Newton:

| asset | `max |jnt_solref − native|` |
| --- | --- |
| converted with 0.1.0a8 (predates these attributes) | 4.5e-10 |
| converted with 0.4.1 | **1.39** |
| converted with this PR | 2.0e-06 |

Native and the pre-0.4.0 asset are `[0.02, 1]` on every joint; 0.4.1 produces per-joint values such as `[0.155, 0.360]` and `[0.347, 0.240]`. The residual 2e-6 here is the float32 round-trip through the USD attribute.

`jnt_solref` is the only field affected — with this PR the converted Apollo matches the pre-0.4.0 asset on every other compared field (`body_mass`, `body_inertia`, `body_ipos`, `dof_damping`, `dof_armature`, `dof_frictionloss`, `jnt_solimp`, `jnt_range`, `dof_invweight0`, …).

The divergence is large enough to fail simulation equivalence for five of the eight structured USD robots in `newton-assets` (Apollo, Booster T1, Wonik Allegro, Shadow Hand, G1 with hands), which is what surfaced this. UR5e passes despite identical authoring because its joints never reach their limits during the compared steps.

### Approach

`get_limit_force_scale()` divides both gains by the DOF's `invweight0` narrowed by the impedance width `solimp[1]` — the same inertia MuJoCo normalizes by, and the same product a consumer applies in reverse. `get_newton_limit_stiffness_damping()` now takes that scale as a required argument so the pure solref conversion stays independently testable.

Resolving a spec joint to its compiled counterpart needs a small helper: conversion compiles a *copy* of the spec, so `MjsJoint.id` is never populated. Named joints resolve through the model; unnamed ones fall back to their position in the spec, which the compiler preserves.

### Known limitation

This makes the authored value depend on the compiled model's inertia at `qpos0` — a configuration-dependent quantity baked into a static asset. That is a real drawback of the effort-space definition and is worth weighing in #3762 before this merges.

## Tests

- `test_newton_limit_gains_are_in_effort_space` (new) converts a hinge and a slide joint with known `solreflimit`, then asserts that undoing the normalization the way a consumer would recovers the authored `(timeconst, dampratio)`. This pins the round-trip property rather than a literal.
- `test_newton_limit_stiffness_damping_from_solreflimit` keeps covering the pure solref conversion by passing a force scale of 1.
- `test_no_autolimits`, `test_mjc_schema`, and `test_joint_equality_schema` state their expectations in the normalized units the MJCF authors, divided by a scale computed from the compiled model via the new `ConverterTestCase.limitForceScale` helper, rather than restating the inertia-dependent product as a literal.

```
uv run --group dev poe test
```

182 tests pass. `uv run --group dev poe lint` is clean.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
