### PR TITLE
Stop authoring limit gains derived from solreflimit

### DIFF
--- a/mujoco_usd_converter/_impl/joint.py
+++ b/mujoco_usd_converter/_impl/joint.py
@@ -67,10 +67,10 @@ def convert_joints(parent: Usd.Prim, body: mujoco.MjsBody, data: ConversionData)
 
         data.references[Tokens.PhysicsJoints][joint.name] = joint_prim.GetPrim()
 
-        apply_mjc_joint_api(joint_prim.GetPrim(), joint, limits[0] is not None and limits[1] is not None)
+        apply_mjc_joint_api(joint_prim.GetPrim(), joint)
 
 
-def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited: bool):
+def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint):
     prim.ApplyAPI("MjcJointAPI")
     prim.ApplyAPI("NewtonJointAPI")
 
@@ -96,40 +96,24 @@ def apply_mjc_joint_api(prim: Usd.Prim, joint: mujoco.MjsJoint, is_joint_limited
     set_schema_attribute(prim, "newton:armature", joint.armature)
     set_schema_attribute(prim, "newton:damping", to_newton_angular_gain(joint, joint.damping[0]))
     set_schema_attribute(prim, "newton:friction", joint.frictionloss)
-    if is_joint_limited:
-        limit_stiffness, limit_damping = get_newton_limit_stiffness_damping(joint)
-        if limit_stiffness is not None:
-            set_schema_attribute(prim, "newton:limitStiffness", limit_stiffness)
-        if limit_damping is not None:
-            set_schema_attribute(prim, "newton:limitDamping", limit_damping)
+    # newton:limitStiffness and newton:limitDamping are deliberately left unauthored.
+    # MJCF describes joint limits only through solreflimit, which is in MuJoCo's
+    # normalized constraint space, while NewtonJointAPI defines those gains as effort per
+    # unit penetration. Deriving one from the other requires the compiled effective
+    # inertia at qpos0, so the asset would bake a configuration-dependent value into a
+    # static attribute. mjc:solreflimit above carries the source values exactly and is
+    # authoritative for SolverMuJoCo. See newton-physics/newton#3762.
 
 
 def to_newton_angular_gain(joint: mujoco.MjsJoint, value: float) -> float:
     """Convert a MuJoCo per-radian gain to the per-degree convention used by NewtonJointAPI.
 
-    MuJoCo authors angular gains (damping, stiffness, limit gains) per radian, while the
-    NewtonJointAPI attributes are per degree. Linear DOFs are unaffected.
+    MuJoCo authors angular gains per radian, while the NewtonJointAPI attributes are per
+    degree. Linear DOFs are unaffected.
     """
     if joint.type in (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_BALL):
         return value * (np.pi / 180.0)
     return value
-
-
-def get_newton_limit_stiffness_damping(joint: mujoco.MjsJoint) -> tuple[float | None, float | None]:
-    timeconst = joint.solref_limit[0]
-    dampratio = joint.solref_limit[1]
-
-    if timeconst < 0.0 and dampratio < 0.0:
-        stiffness = -timeconst
-        damping = -dampratio
-    else:
-        if timeconst <= 0.0 or dampratio <= 0.0:
-            return None, None
-        stiffness = 1.0 / (timeconst * timeconst * dampratio * dampratio)
-        damping = 2.0 / timeconst
-
-    # NewtonJointAPI angular limit stiffness/damping are authored per degree.
-    return to_newton_angular_gain(joint, stiffness), to_newton_angular_gain(joint, damping)
 
 
 def is_limited(joint: mujoco.MjsJoint, data: ConversionData) -> bool:

--- a/tests/data/joint_limits_no_autolimits.xml
+++ b/tests/data/joint_limits_no_autolimits.xml
@@ -19,7 +19,7 @@
             </body>
         </body>
 
-        <!-- Direct-mode solreflimit should author Newton limit gains. -->
+        <!-- Direct-mode solreflimit, which encodes (-stiffness, -damping). -->
         <body name="body5">
             <geom type="box" size="0.1 0.1 0.1"/>
             <body name="body6">
@@ -28,7 +28,7 @@
             </body>
         </body>
 
-        <!-- Linear joints should not use angular per-degree scaling. -->
+        <!-- Standard-mode solreflimit, which encodes (timeconst, dampratio). -->
         <body name="body7">
             <geom type="box" size="0.1 0.1 0.1"/>
             <body name="body8">

--- a/tests/testEqualities.py
+++ b/tests/testEqualities.py
@@ -381,17 +381,16 @@ class TestEqualities(ConverterTestCase):
         self.assertEqual(len(targets), 1)
         self.assertEqual("/equality_joint_attributes/Geometry/body2/body3/slide1", str(targets[0]))
         self.assertTrue(default_joint.GetAttribute("newton:mimicEnabled").Get())
-        self.assertAlmostEqual(default_joint.GetAttribute("newton:limitStiffness").Get(), 2500)
-        self.assertAlmostEqual(default_joint.GetAttribute("newton:limitDamping").Get(), 100)
 
         # Check that only required relationships and Newton joint values whose schema defaults differ are authored.
         # mimicCoef0 is authored here because the fixture gives the slide follower a
         # non-zero offset; a zero offset would match the schema default and be skipped.
+        # The limit gains stay unauthored even though this joint is limited: the fixture
+        # leaves solreflimit at the MuJoCo default, so there is nothing non-default to say
+        # about the limit in either representation.
         authored_properties = [
             "newton:mimicJoint",
             "newton:mimicCoef0",
-            "newton:limitStiffness",
-            "newton:limitDamping",
         ]
         for property in default_joint.GetPropertiesInNamespace("newton"):
             if property.GetName() in authored_properties:

--- a/tests/testJoints.py
+++ b/tests/testJoints.py
@@ -3,54 +3,13 @@
 import math
 import pathlib
 
-import mujoco
 from pxr import Gf, Sdf, Usd, UsdPhysics
 
 import mujoco_usd_converter
-from mujoco_usd_converter._impl.joint import get_newton_limit_stiffness_damping
 from tests.util.ConverterTestCase import ConverterTestCase
 
 
 class TestJoints(ConverterTestCase):
-
-    def test_newton_limit_stiffness_damping_from_solreflimit(self):
-        spec = mujoco.MjSpec()
-        body = spec.worldbody.add_body(name="limit_gain_test_body")
-
-        def add_joint(name, joint_type, solref_limit):
-            joint = body.add_joint(name=name, type=joint_type)
-            joint.solref_limit = solref_limit
-            return joint
-
-        # Standard positive solref mode:
-        #   stiffness = 1 / (timeconst^2 * dampratio^2)
-        #   damping = 2 / timeconst
-        linear_joint = add_joint("linear_joint", mujoco.mjtJoint.mjJNT_SLIDE, [0.04, 0.5])
-        stiffness, damping = get_newton_limit_stiffness_damping(linear_joint)
-        self.assertAlmostEqual(stiffness, 2500.0)
-        self.assertAlmostEqual(damping, 50.0)
-
-        # Hinge/ball limit gains are authored in USD's per-degree angular units.
-        hinge_joint = add_joint("hinge_joint", mujoco.mjtJoint.mjJNT_HINGE, [0.04, 0.5])
-        stiffness, damping = get_newton_limit_stiffness_damping(hinge_joint)
-        self.assertAlmostEqual(stiffness, 2500.0 * math.pi / 180.0)
-        self.assertAlmostEqual(damping, 50.0 * math.pi / 180.0)
-
-        ball_joint = add_joint("ball_joint", mujoco.mjtJoint.mjJNT_BALL, [0.04, 0.5])
-        stiffness, damping = get_newton_limit_stiffness_damping(ball_joint)
-        self.assertAlmostEqual(stiffness, 2500.0 * math.pi / 180.0)
-        self.assertAlmostEqual(damping, 50.0 * math.pi / 180.0)
-
-        # Direct negative solref mode encodes (-stiffness, -damping).
-        direct_joint = add_joint("direct_joint", mujoco.mjtJoint.mjJNT_SLIDE, [-12.0, -3.0])
-        stiffness, damping = get_newton_limit_stiffness_damping(direct_joint)
-        self.assertAlmostEqual(stiffness, 12.0)
-        self.assertAlmostEqual(damping, 3.0)
-
-        # Invalid mixed-sign or zero values are not converted.
-        for index, solref_limit in enumerate(([0.0, 1.0], [0.04, 0.0], [-12.0, 3.0], [12.0, -3.0])):
-            joint = add_joint(f"invalid_joint_{index}", mujoco.mjtJoint.mjJNT_SLIDE, solref_limit)
-            self.assertEqual(get_newton_limit_stiffness_damping(joint), (None, None))
 
     def test_newton_damping_is_per_degree(self):
         # MuJoCo authors joint damping per radian, but NewtonJointAPI authors it per degree,
@@ -449,28 +408,40 @@ class TestJoints(ConverterTestCase):
         self.assertFalse(unlimited_joint.GetLowerLimitAttr().HasAuthoredValue())
         self.assertFalse(unlimited_joint.GetUpperLimitAttr().HasAuthoredValue())
 
-        # Direct-mode solreflimit encodes stiffness and damping directly, then
-        # angular joints are authored in the per-degree units expected by USD.
+        # A limit constraint is carried by mjc:solreflimit alone. The Newton-generic gains
+        # are effort per unit penetration, which MJCF does not express, so they stay
+        # unauthored and fall back to the schema sentinel. See newton-physics/newton#3762.
         direct_limit_joint = UsdPhysics.RevoluteJoint(stage.GetPrimAtPath("/joint_limits_no_autolimits/Geometry/body5/body6/direct_limit_joint"))
         self.assertTrue(direct_limit_joint.GetLowerLimitAttr().HasAuthoredValue())
         self.assertAlmostEqual(direct_limit_joint.GetLowerLimitAttr().Get(), -20)
         self.assertAlmostEqual(direct_limit_joint.GetUpperLimitAttr().Get(), 20)
         direct_limit_prim = direct_limit_joint.GetPrim()
-        self.assertTrue(direct_limit_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
-        self.assertAlmostEqual(direct_limit_prim.GetAttribute("newton:limitStiffness").Get(), 12 * math.pi / 180.0)
-        self.assertTrue(direct_limit_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
-        self.assertAlmostEqual(direct_limit_prim.GetAttribute("newton:limitDamping").Get(), 3 * math.pi / 180.0)
+        # Direct-mode solreflimit encodes (-stiffness, -damping) and round trips verbatim.
+        self.assertTrue(direct_limit_prim.GetAttribute("mjc:solreflimit").HasAuthoredValue())
+        actual_solreflimit = direct_limit_prim.GetAttribute("mjc:solreflimit").Get()
+        for i, expected in enumerate((-12.0, -3.0)):
+            self.assertAlmostEqual(actual_solreflimit[i], expected, places=5)
+        self.assertFalse(direct_limit_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
+        self.assertFalse(direct_limit_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
 
-        # Prismatic joints use the raw linear stiffness/damping conversion.
         linear_limit_joint = UsdPhysics.PrismaticJoint(stage.GetPrimAtPath("/joint_limits_no_autolimits/Geometry/body7/body8/linear_limit_joint"))
         self.assertTrue(linear_limit_joint.GetLowerLimitAttr().HasAuthoredValue())
         self.assertAlmostEqual(linear_limit_joint.GetLowerLimitAttr().Get(), -0.2)
         self.assertAlmostEqual(linear_limit_joint.GetUpperLimitAttr().Get(), 0.4)
         linear_limit_prim = linear_limit_joint.GetPrim()
-        self.assertTrue(linear_limit_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
-        self.assertAlmostEqual(linear_limit_prim.GetAttribute("newton:limitStiffness").Get(), 2500)
-        self.assertTrue(linear_limit_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
-        self.assertAlmostEqual(linear_limit_prim.GetAttribute("newton:limitDamping").Get(), 50)
+        self.assertTrue(linear_limit_prim.GetAttribute("mjc:solreflimit").HasAuthoredValue())
+        actual_solreflimit = linear_limit_prim.GetAttribute("mjc:solreflimit").Get()
+        for i, expected in enumerate((0.04, 0.5)):
+            self.assertAlmostEqual(actual_solreflimit[i], expected, places=5)
+        self.assertFalse(linear_limit_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
+        self.assertFalse(linear_limit_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
+
+        # A limited joint that leaves solreflimit at the MuJoCo default authors neither
+        # representation, so both fall back to their schema defaults.
+        limited_prim = limited_joint.GetPrim()
+        self.assertFalse(limited_prim.GetAttribute("mjc:solreflimit").HasAuthoredValue())
+        self.assertFalse(limited_prim.GetAttribute("newton:limitStiffness").HasAuthoredValue())
+        self.assertFalse(limited_prim.GetAttribute("newton:limitDamping").HasAuthoredValue())
 
     def test_mjc_schema(self):
         # Test that all joint attributes are authored correctly
@@ -546,10 +517,10 @@ class TestJoints(ConverterTestCase):
         self.assertTrue(custom_joint.GetAttribute("newton:friction").HasAuthoredValue())
         self.assertAlmostEqual(custom_joint.GetAttribute("newton:friction").Get(), 0.2)
         self.assertFalse(custom_joint.GetAttribute("newton:velocityLimit").HasAuthoredValue())
-        self.assertTrue(custom_joint.GetAttribute("newton:limitStiffness").HasAuthoredValue())
-        self.assertAlmostEqual(custom_joint.GetAttribute("newton:limitStiffness").Get(), 40000 * math.pi / 180.0, places=4)
-        self.assertTrue(custom_joint.GetAttribute("newton:limitDamping").HasAuthoredValue())
-        self.assertAlmostEqual(custom_joint.GetAttribute("newton:limitDamping").Get(), 200 * math.pi / 180.0, places=4)
+        # The custom solreflimit above is the only representation of the limit constraint;
+        # the Newton-generic gains are not derived from it.
+        self.assertFalse(custom_joint.GetAttribute("newton:limitStiffness").HasAuthoredValue())
+        self.assertFalse(custom_joint.GetAttribute("newton:limitDamping").HasAuthoredValue())
 
         # A joint with explicitly authored default values in MJC does not need to author any values in USD
         default_joint: Usd.Prim = stage.GetPrimAtPath("/joint_attributes/Geometry/body2/default_joint")


### PR DESCRIPTION
## Description

Since 0.4.0 we have derived `newton:limitStiffness` / `newton:limitDamping` from `mjc:solreflimit`, applying only per-degree angular scaling. That conversion is in the wrong space.

MJCF describes a joint limit only through `solreflimit`, which lives in MuJoCo's normalized (acceleration) constraint space. `NewtonJointAPI` defines those gains as effort per unit penetration. The two differ by the constraint's effective inertia, so the authored value carried MuJoCo's normalized magnitude in an attribute documented as effort, and a consumer that undid the normalization recovered a different `solref` than the source MJCF.

Converting properly *is* possible — I prototyped it in #113 and it recovers Apollo's source `solref` to 2e-6 — but it requires the compiled effective inertia at `qpos0`, which bakes a configuration-dependent quantity into a static asset.

[newton-physics/newton#3762](https://github.com/newton-physics/newton/issues/3762) has since resolved the underlying units question. Generic Newton attributes describe portable physical quantities; solver-specific attributes keep their native solver semantics; and for a consuming solver the most specific authored representation wins. Under that split the right answer is to author neither gain: MJCF simply does not contain effort-space limit gains, so there is nothing to convert.

Nothing is lost. `mjc:solreflimit` is still authored with the source values exactly and is authoritative for `SolverMuJoCo`. Other solvers now fall back to their own limit defaults, which matches what `import_mjcf` is being changed to do for the same reason (item 4 of the resolution).

### Side effect worth calling out

This also stops a limited joint that says *nothing* about `solreflimit` from acquiring a hard-coded `2500` / `100` pair. Such joints leave `solreflimit` at the MuJoCo default `[0.02, 1]`, so `set_schema_attribute` correctly sparsifies it away — but the derived gains differed from the `NewtonJointAPI` `-inf` sentinel and were written out regardless. The `equality_joint_attributes` fixture shows exactly this. That is the same `2500`/`100` sentinel pair the Newton side is working to stop treating as a physical gain.

### Testing

- Removed `test_newton_limit_stiffness_damping_from_solreflimit`, which covered the deleted conversion.
- `test_no_autolimits` now asserts `mjc:solreflimit` round trips verbatim in both direct `(-stiffness, -damping)` and standard `(timeconst, dampratio)` modes, and that neither generic gain is authored. Added a case for a limited joint at the MuJoCo default, which authors neither representation.
- `test_mjc_schema` and `test_joint_equality_schema` assert the gains stay unauthored.
- Verified the updated tests fail against the old `joint.py` (3 failures) and pass with it. Full suite: 180 passed. `poe lint` clean.

No `CHANGELOG.md` entry — this repo writes its changelog section at release prep, and v0.4.1 is already tagged.

Supersedes #113, which is closed but left intact as the reference if we ever want an explicit opt-in bake for portable cross-solver gains.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).