### PR TITLE
Update to mujoco 3.11

### DIFF
--- a/mujoco_usd_converter/_impl/material.py
+++ b/mujoco_usd_converter/_impl/material.py
@@ -87,7 +87,9 @@ def convert_material(parent: Usd.Prim, name: str, material: mujoco.MjsMaterial, 
 
 
 def convert_texture(texture: mujoco.MjsTexture, data: ConversionData) -> Sdf.AssetPath:
-    if texture.builtin:
+    # Compare explicitly rather than testing truthiness: mujoco 3.11 returns an mjtBuiltin
+    # enum member here rather than an int, and every member is truthy, including mjBUILTIN_NONE.
+    if texture.builtin != mujoco.mjtBuiltin.mjBUILTIN_NONE:
         Tf.Warn(f"Unsupported builtin texture type {mujoco.mjtBuiltin(texture.builtin)} for texture '{texture.name}'")
         return Sdf.AssetPath()
     elif texture.type == mujoco.mjtTexture.mjTEXTURE_2D:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "mujoco>=3.10.0,<3.11",
+    "mujoco>=3.11.0,<3.12",
     "usd-exchange>=2.2.2", # locked to USD 25.05
     "newton-usd-schemas>=0.4.0",
     "numpy-stl>=3.2",

--- a/tests/data/builtin_textures.xml
+++ b/tests/data/builtin_textures.xml
@@ -1,0 +1,18 @@
+<mujoco model="builtin_textures">
+    <compiler meshdir="assets" texturedir="assets"/>
+
+    <asset>
+        <!-- A builtin texture is procedural, so there is no file to reference and it is skipped -->
+        <texture name="gradient_texture" type="skybox" builtin="gradient" rgb1="1 1 1" rgb2="0 0 0" width="32" height="32"/>
+        <material name="Gradient" texture="gradient_texture" specular="0"/>
+        <!-- A file backed texture in the same model must still be converted -->
+        <texture name="grid_texture" type="2d" file="grid.png"/>
+        <material name="Grid" texture="grid_texture" specular="0"/>
+        <mesh name="box" file="box.obj" scale="0.2 0.2 1"/>
+    </asset>
+
+    <worldbody>
+        <geom name="GradientBox" type="mesh" mesh="box" material="Gradient" pos="0 0 0"/>
+        <geom name="TexturedBox" type="mesh" mesh="box" material="Grid" pos="1 0 0"/>
+    </worldbody>
+</mujoco>

--- a/tests/testMaterial.py
+++ b/tests/testMaterial.py
@@ -152,21 +152,22 @@ class TestBuiltinTexture(ConverterTestCase):
     def _get_input_value(self, shader: UsdShade.Shader, input_name: str):
         return UsdShade.Utils.GetValueProducingAttributes(shader.GetInput(input_name))[0].Get()
 
-    def _get_diffuse_source(self, material_name: str) -> UsdShade.Shader:
+    def _get_diffuse_source_prim(self, material_name: str) -> Usd.Prim:
         # Every preview material connects diffuseColor to its material interface, so the
         # texture is identified by the connected source being a UsdUVTexture reader.
         shader = self._get_shader(material_name)
         connected_source = shader.GetInput("diffuseColor").GetConnectedSource()
-        return UsdShade.Shader(connected_source[0].GetPrim())
+        self.assertTrue(connected_source)
+        return connected_source[0].GetPrim()
 
     def test_builtin_texture_is_skipped(self):
-        source = self._get_diffuse_source("Gradient")
-        self.assertNotEqual(source.GetShaderId(), "UsdUVTexture")
-        self.assertFalse(source.GetInput("file"))
+        source_prim = self._get_diffuse_source_prim("Gradient")
+        self.assertEqual(str(source_prim.GetPath()), f"/{self.model_name}/Materials/Gradient")
+        self.assertEqual(source_prim.GetTypeName(), "Material")
         self.assertFalse(self.stage.GetPrimAtPath(f"/{self.model_name}/Materials/Gradient/DiffuseTexture"))
 
     def test_file_texture_still_converts(self):
-        source = self._get_diffuse_source("Grid")
+        source = UsdShade.Shader(self._get_diffuse_source_prim("Grid"))
         self.assertEqual(source.GetShaderId(), "UsdUVTexture")
         self.assertEqual(self._get_input_value(source, "file").path, "./Textures/grid.png")
         self.assertTrue((self.output_dir / "Payload" / "Textures" / "grid.png").exists())

--- a/tests/testMaterial.py
+++ b/tests/testMaterial.py
@@ -125,3 +125,52 @@ class TestMaterial(ConverterTestCase):
         self.assertTrue(Gf.IsClose(diffuse_color, Gf.Vec3f(0.3, 0.8, 0.9), 1e-6))
         emissive_color = self._get_input_value(shader, "emissiveColor")
         self.assertTrue(Gf.IsClose(usdex.core.linearToSrgb(emissive_color / 0.2), diffuse_color, 1e-6))
+
+
+class TestBuiltinTexture(ConverterTestCase):
+    """Only procedural builtin textures are skipped; file backed textures in the same model still convert."""
+
+    def setUp(self):
+        super().setUp()
+        model_path = pathlib.Path("./tests/data/builtin_textures.xml")
+        self.model_name = model_path.stem
+        self.output_dir = pathlib.Path(self.tmpDir())
+        with usdex.test.ScopedDiagnosticChecker(
+            self,
+            [(Tf.TF_DIAGNOSTIC_WARNING_TYPE, ".*Unsupported builtin texture type.*gradient_texture")],
+            level=usdex.core.DiagnosticsLevel.eWarning,
+        ):
+            asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model_path, self.output_dir)
+        self.stage: Usd.Stage = Usd.Stage.Open(asset.path)
+        self.assertIsValidUsd(self.stage)
+
+    def _get_shader(self, material_name: str) -> UsdShade.Shader:
+        material_prim = self.stage.GetPrimAtPath(f"/{self.model_name}/Materials/{material_name}")
+        self.assertTrue(material_prim)
+        return usdex.core.computeEffectivePreviewSurfaceShader(UsdShade.Material(material_prim))
+
+    def _get_input_value(self, shader: UsdShade.Shader, input_name: str):
+        return UsdShade.Utils.GetValueProducingAttributes(shader.GetInput(input_name))[0].Get()
+
+    def _get_diffuse_source(self, material_name: str) -> UsdShade.Shader:
+        # Every preview material connects diffuseColor to its material interface, so the
+        # texture is identified by the connected source being a UsdUVTexture reader.
+        shader = self._get_shader(material_name)
+        connected_source = shader.GetInput("diffuseColor").GetConnectedSource()
+        return UsdShade.Shader(connected_source[0].GetPrim())
+
+    def test_builtin_texture_is_skipped(self):
+        source = self._get_diffuse_source("Gradient")
+        self.assertNotEqual(source.GetShaderId(), "UsdUVTexture")
+        self.assertFalse(source.GetInput("file"))
+        self.assertFalse(self.stage.GetPrimAtPath(f"/{self.model_name}/Materials/Gradient/DiffuseTexture"))
+
+    def test_file_texture_still_converts(self):
+        source = self._get_diffuse_source("Grid")
+        self.assertEqual(source.GetShaderId(), "UsdUVTexture")
+        self.assertEqual(self._get_input_value(source, "file").path, "./Textures/grid.png")
+        self.assertTrue((self.output_dir / "Payload" / "Textures" / "grid.png").exists())
+
+    def test_only_the_file_texture_is_copied(self):
+        textures = sorted(path.name for path in (self.output_dir / "Payload" / "Textures").iterdir())
+        self.assertEqual(textures, ["grid.png"])

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -293,7 +293,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.10.0"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -303,23 +303,20 @@ dependencies = [
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/3b/c76837b7fdb007f7605ff783689a0bd23a5a49b065928bec2f1fa7ea3d67/mujoco-3.10.0.tar.gz", hash = "sha256:c9e8d5d87d82204ed5bccc87d843c0a53e75aaf381de2938ec46d04f1ac6e24e", size = 1094987, upload-time = "2026-06-22T17:40:59.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/2d/290f3f4062eec1c0d5246de0a75f1b18b59a1961081f49ddc97333fc8263/mujoco-3.11.0.tar.gz", hash = "sha256:390856102af9547dfd87cb2791eb105a3d2e00a37323fe9a12ed17e512aff1a6", size = 1139880, upload-time = "2026-07-28T01:23:32.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/ed/9b8df6c801fa25542d4c2dc417063611474a070c4bef52e896fa57726d94/mujoco-3.10.0-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:c1c9dfb4ba3f1ef14b70968e9cd41b14fa1877f9697369953a471aa17324f443", size = 7745281, upload-time = "2026-06-22T17:39:47.198Z" },
-    { url = "https://files.pythonhosted.org/packages/09/be/3d9a1ecfe3501a84ece0d5824ff67a0933337650fb48b26c8db0b43de0cd/mujoco-3.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c8e4688d87b85be27dfcfdf957f05f1450a99131f9f8b1818613a2e4fd8d7321", size = 19324219, upload-time = "2026-06-22T17:39:49.666Z" },
-    { url = "https://files.pythonhosted.org/packages/03/37/5580b126403510a80a059a66d3ea21f3e55d47960e480e66ff2a7723b514/mujoco-3.10.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4e1e2c0c72200340d413da4211b56a8885a7ed78e893f36d97e5696e8f4af3e", size = 19628590, upload-time = "2026-06-22T17:39:53.624Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3c/e3768418794c4450c6bef971eaa2314e1fac7d46abc6968b6722b0b654a0/mujoco-3.10.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47a89c371cc171a38eb6c03172aff2f905e54c1261d87b3575a9d77fe3a29a55", size = 20763444, upload-time = "2026-06-22T17:39:56.559Z" },
-    { url = "https://files.pythonhosted.org/packages/af/3c/a3c5121ca9356e78dd1f09ad48e7fa034b91e02124d533e64252c314b646/mujoco-3.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:2f71cb614559cd06a8ce57bd255146e15ccb49ee7dea316aeb895838ba82e1e0", size = 17719988, upload-time = "2026-06-22T17:39:59.614Z" },
-    { url = "https://files.pythonhosted.org/packages/45/bd/c3a4ad6884e60bbbff3d77df75358570bcf9b97ff8d81a0ea3b311b0276e/mujoco-3.10.0-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:62b7e9faf714f1582e1dd923ba3ea769a939cc572f6d77909752cbb31db5409f", size = 7758349, upload-time = "2026-06-22T17:40:02.329Z" },
-    { url = "https://files.pythonhosted.org/packages/41/69/4c55c05fe602d72be5526d911e6802de1e67ad70c9301f556eef1d78a4bb/mujoco-3.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b812e0e36e8b2dde8ce4ad9b25e189b658b9c94f5e798aa64783261abb88321", size = 19348907, upload-time = "2026-06-22T17:40:04.634Z" },
-    { url = "https://files.pythonhosted.org/packages/05/19/a8a560f29f7f0137da6d41d633bc892a9e8ebc36af64c31a3db5882d26d8/mujoco-3.10.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0eff9fb64c39c21f5e29f39996c152ed9a2a5c783818b524c77abf41f6e5751", size = 19654107, upload-time = "2026-06-22T17:40:07.594Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/07/a37fc7fa55d38e9225884b80c3d241e669357e83f7e23f80b8860a7e14cd/mujoco-3.10.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5489e18a8dd09da2dd71d28563e17889a2e5a0ad07943ebcaa1446d6c4d4e1dd", size = 20789312, upload-time = "2026-06-22T17:40:10.656Z" },
-    { url = "https://files.pythonhosted.org/packages/82/84/6548d32afc49fb79015a0b98d1119628ce94dd8befb4526c2cd10429e13f/mujoco-3.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:45a27a8982e6f89f09e87e4578a5d3e7c9b5667f3db07052e518993b78c9b3ea", size = 17757305, upload-time = "2026-06-22T17:40:13.448Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a2/4dd9f4cec6ce92f836a8b2de1cc799c4458af1467d7a044ef8014217bdb4/mujoco-3.10.0-cp312-cp312-macosx_10_16_x86_64.whl", hash = "sha256:47d4a22b7667c60e24e7ef6acb027c13abe9abba9acf17cc8db6fb250ba275ea", size = 7772567, upload-time = "2026-06-22T17:40:16.539Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7d/ebe5342c136de27e0c430ba781f829df2cd66c00ed22627c1964fbd5d7fe/mujoco-3.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4d35e9d0b13ff9ad3196294a7dac363f1d0cdaa988832d0b687d42d98f4ee29", size = 19380823, upload-time = "2026-06-22T17:40:19.211Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5d/43d1b2b9fe97676e5af03020e132ac497b45a0333a4c61de657d0d52170a/mujoco-3.10.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb7f0d7c148a588f3633020807fc0ec3f3a9aff1f647406e3e0ffe96b05dfd57", size = 19705628, upload-time = "2026-06-22T17:40:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/11/c69199e4123935f98068ab6ab6b35955b4de0f6a91d3f9883805a5789394/mujoco-3.10.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:966d12f88e77e2b188e7530667b519d6963b9b906cff83bab534e5e4279325a0", size = 20904309, upload-time = "2026-06-22T17:40:25.861Z" },
-    { url = "https://files.pythonhosted.org/packages/47/13/07bf2550c7dcd69ee8c7fd1f5c400a4ba2e4ede0a29a463ad3ac4cc9da90/mujoco-3.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:708edb5aceee96f2767b1072641523060043b2c67000e39e6e9797addf073696", size = 17865123, upload-time = "2026-06-22T17:40:28.996Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/4f/cac3ffdff6fbd63860d1be28a7f45fa1206ed638d4c774fe4505b9563c7c/mujoco-3.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6d830dab9f43781980d1e673f06938d80261f9960d8086d8a221ba0118b68c79", size = 17455595, upload-time = "2026-07-28T01:22:20.595Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f5/f8dfdbc9964b24bb1c2fb60467474d7a85f160c609ce29099d6eda9806ec/mujoco-3.11.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aac0102660762fad316cea63b81765593c97bdda0e22251eb64ff561f78e6853", size = 17632593, upload-time = "2026-07-28T01:22:23.616Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f5/9bb09c44bbc7b3d844aed8517f130cbc99e565b5f5e8a55c8f06f40b8129/mujoco-3.11.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39b813755f4b09b75a0ccaec0e1e37d313bc7c9ca1be94203a9aae3b7829cae0", size = 18727136, upload-time = "2026-07-28T01:22:26.625Z" },
+    { url = "https://files.pythonhosted.org/packages/43/40/e5123f0502dbb61158fa8f73b6d5576d3a818e3b3b07794732760759acf8/mujoco-3.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:c82557572b279dd61540f2da6d61afed64ef765c210e24abeee4f2b2a57660bb", size = 15651634, upload-time = "2026-07-28T01:22:29.765Z" },
+    { url = "https://files.pythonhosted.org/packages/82/cb/eaa909bfdb093d82b80518182db89936fd0cc5486aeac31e71d9940e4800/mujoco-3.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:87a70b79d461b3afe03d1cd3dfb44b9ba1955a80b011a87c9536a6ef9c7936c8", size = 17474359, upload-time = "2026-07-28T01:22:32.578Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d6/74fcb2a95b21de5217f19d9eb87db923d337e204da4dedaffeacababd28a/mujoco-3.11.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d09bcec0d9338fd79095314c4bd3a3072d7063e94a27d47f78e6159ca9a2baa9", size = 17655486, upload-time = "2026-07-28T01:22:35.33Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3d/3c933a7a8e7f00e12260ad175195b8bbc36fd3aa62068f00db36351a2147/mujoco-3.11.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:16f94f05745225aaafb68016cbd2a1617f4af6b4bfca6c97d22c7b14e598d1f1", size = 18751041, upload-time = "2026-07-28T01:22:38.149Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/e09d6ac38f3e7af2fec0b3501515973f8a400d9c3d1e22e727a21762f598/mujoco-3.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:5a286601c6a73a21f576ac6405e842a3221eb7db53013084a5c2e341a35112ee", size = 15687351, upload-time = "2026-07-28T01:22:40.864Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b3/b2b449b5978bcb13277c9e50d764e6d8cd9534f58f071fb1647724123e2c/mujoco-3.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3609c198de090c8218b9cc62ca6133f0feede8edd103b743b8002f3f735fcd9b", size = 17511145, upload-time = "2026-07-28T01:22:43.668Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/65/d8130bb8a673f9cdc8a8fb2ef02f9b6931708567de57f17395106e83b4e3/mujoco-3.11.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:517bff03623c3329a563f575afd7d731b0be5c4f92a54dcec934b99120b4a9ec", size = 17704436, upload-time = "2026-07-28T01:22:47.05Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/7b79f5d8fbd019658a3b5feb6ffd09c1e727eaf93f518685d3cc105a28f5/mujoco-3.11.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f40214fefc8c2fe0002a3c8abadf30de7a3330634f3c45cc29b407b40a0173fc", size = 18868030, upload-time = "2026-07-28T01:22:50.494Z" },
+    { url = "https://files.pythonhosted.org/packages/19/46/f994cd7d973c4db4f6b5af19ba6eb62703b9aafc8f894c5bc5ceadd31b0d/mujoco-3.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:98c08a5eec9411ecd6f763f1e635fbc8f31e3ea3701584d6b7edcc24d8d6c575", size = 15791637, upload-time = "2026-07-28T01:22:53.922Z" },
 ]
 
 [[package]]
@@ -347,7 +344,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mujoco", specifier = ">=3.10.0,<3.11" },
+    { name = "mujoco", specifier = ">=3.11.0,<3.12" },
     { name = "newton-usd-schemas", specifier = ">=0.4.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },


### PR DESCRIPTION
## Description

Bumps `mujoco` from `>=3.10.0,<3.11` to `>=3.11.0,<3.12`. Newton 1.5 requires `mujoco~=3.11.0`, so the old pin made the converter and Newton mutually uninstallable.

3.11 returns an `mjtBuiltin` enum from `MjsTexture.builtin` rather than an `int`, and every pybind11 enum member is truthy — including `mjBUILTIN_NONE` — so `if texture.builtin:` discarded every texture. Now compares against `mjBUILTIN_NONE` explicitly, which behaves the same on both versions. That was the only place the converter tested a newly-enum field for truthiness.

Also adds coverage for builtin textures, which had none.

183 tests pass. Converted output is byte-identical to 0.4.2, and so is the downloaded `mjcPhysics` schema.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
