### PR TITLE
Stop disabling the follower joint for an inactive joint equality

### DIFF
--- a/mujoco_usd_converter/_impl/equality.py
+++ b/mujoco_usd_converter/_impl/equality.py
@@ -192,13 +192,8 @@ def convert_equality(
         set_schema_attribute(joint_prim, "mjc:coef2", equality.data[2])
         set_schema_attribute(joint_prim, "mjc:coef3", equality.data[3])
         set_schema_attribute(joint_prim, "mjc:coef4", equality.data[4])
-        # Deliberately no physics:jointEnabled here, unlike the weld and connect branches
-        # above. Those author it on a prim created for the equality, so it describes the
-        # equality; this branch borrows the follower joint, where it is that joint's own
-        # gate. The follower is an ordinary DOF that outlives the constraint -- MuJoCo's
-        # eq_active is per-equality and runtime-settable -- so newton:mimicEnabled carries
-        # the active state on its own. See google-deepmind/mujoco#3472 for the decoder
-        # side, which reads only physics:jointEnabled today.
+        # No physics:jointEnabled here: this branch borrows the follower joint, where the
+        # attribute gates the joint itself. newton:mimicEnabled above carries the equality.
 
         return joint_prim, False
 

--- a/mujoco_usd_converter/_impl/equality.py
+++ b/mujoco_usd_converter/_impl/equality.py
@@ -192,7 +192,13 @@ def convert_equality(
         set_schema_attribute(joint_prim, "mjc:coef2", equality.data[2])
         set_schema_attribute(joint_prim, "mjc:coef3", equality.data[3])
         set_schema_attribute(joint_prim, "mjc:coef4", equality.data[4])
-        set_schema_attribute(joint_prim, "physics:jointEnabled", equality.active)
+        # Deliberately no physics:jointEnabled here, unlike the weld and connect branches
+        # above. Those author it on a prim created for the equality, so it describes the
+        # equality; this branch borrows the follower joint, where it is that joint's own
+        # gate. The follower is an ordinary DOF that outlives the constraint -- MuJoCo's
+        # eq_active is per-equality and runtime-settable -- so newton:mimicEnabled carries
+        # the active state on its own. See google-deepmind/mujoco#3472 for the decoder
+        # side, which reads only physics:jointEnabled today.
 
         return joint_prim, False
 

--- a/tests/testEqualities.py
+++ b/tests/testEqualities.py
@@ -249,8 +249,9 @@ class TestEqualities(ConverterTestCase):
         self.assertTrue(joint_weld_nested_bodies.GetJointEnabledAttr().Get())
 
     def test_joint_equality_joint_enabled(self):
-        # XML active="true" (default) - joint enabled, attr should not be authored when default
-        # XML active="false" - joint disabled, physics:jointEnabled must be authored and false
+        # A joint equality is authored onto the follower joint, which exists independently of
+        # the constraint, so physics:jointEnabled stays the joint's own gate and is never
+        # authored from equality.active. newton:mimicEnabled carries the active state.
         model = pathlib.Path("./tests/data/equality_joint_attributes.xml")
         asset: Sdf.AssetPath = mujoco_usd_converter.Converter().convert(model, self.tmpDir())
         stage: Usd.Stage = Usd.Stage.Open(asset.path)
@@ -270,16 +271,17 @@ class TestEqualities(ConverterTestCase):
         self.assertTrue(default_joint_prim.HasAPI("NewtonMimicAPI"))
         self.assertTrue(default_joint_prim.GetAttribute("newton:mimicEnabled").Get())
 
-        # Disabled joint equality: attr must be authored and false (hinge2 has disabled_joint_eq)
+        # Inactive joint equality (hinge2 has disabled_joint_eq): the constraint is off, but the
+        # follower joint is untouched, so physics:jointEnabled is left at its default.
         disabled_joint_prim: Usd.Prim = stage.GetPrimAtPath("/equality_joint_attributes/Geometry/body4/hinge2")
         self.assertTrue(disabled_joint_prim.IsValid())
         disabled_joint = UsdPhysics.RevoluteJoint(disabled_joint_prim)
         disabled_joint_enabled_attr = disabled_joint.GetJointEnabledAttr()
-        self.assertTrue(
+        self.assertFalse(
             self.__has_authored_value(disabled_joint_enabled_attr),
-            "physics:jointEnabled should be authored when joint equality is inactive",
+            "physics:jointEnabled should not be authored from an inactive joint equality",
         )
-        self.assertFalse(disabled_joint_enabled_attr.Get(), "Disabled joint equality should have jointEnabled false")
+        self.assertTrue(disabled_joint_enabled_attr.Get(), "The follower joint itself stays enabled")
 
         self.assertTrue(disabled_joint_prim.HasAPI("NewtonMimicAPI"))
         self.assertFalse(disabled_joint_prim.GetAttribute("newton:mimicEnabled").Get())


### PR DESCRIPTION
## Description

The `mjEQ_JOINT` branch of `convert_equality` authored `physics:jointEnabled = equality.active` onto the follower joint. That disables the **joint**, not the coupling.

The three equality branches are not structurally alike:

- `mjEQ_WELD` and `mjEQ_CONNECT` call `DefinePrim(...)` and build a joint that exists solely to express the equality. Remove the `<equality>` and the joint disappears with it, so `physics:jointEnabled` genuinely describes the equality. **Unchanged by this PR.**
- `mjEQ_JOINT` creates no prim. It looks up *both* joints in the existing registry — `joint_prim = references[equality.name1]` (the follower, which receives the APIs) and `references[equality.name2]` (the leader, which becomes the `newton:mimicJoint` target). `equality_prim` is never assigned in this branch; its only two appearances are failure-path early returns. The follower comes from an MJCF `<joint>` and outlives the constraint, so `physics:jointEnabled` there is that joint's own gate.

MuJoCo's model keeps the two concepts separate, which is the clearest evidence they should not be collapsed:

```c
mjModel: mjtBool* eq_active0;   // initial enable/disable constraint state   (neq x 1)
mjData:  mjtBool* eq_active;    // enable/disable constraints                (neq x 1)
```

Both are dimensioned `neq`, not `njnt` or `nv`, and the XML reference states that `eq_active0` merely seeds `mjData.eq_active`, "which is user-settable at runtime". So `active="false"` is the *initial* state of a toggleable constraint, not a structural property — baking it into the asset as a disabled joint converts a runtime flag into a permanent one, on top of disabling the wrong object.

`newton:mimicEnabled` is already authored from `equality.active` immediately above and carries the state correctly, so the fix is simply to stop writing `physics:jointEnabled` here.

### Known consequence

MuJoCo's USD decoder currently derives `eq->active` **only** from `physics:jointEnabled` and never reads `newton:mimicEnabled` — it is not even in its token list. So until [google-deepmind/mujoco#3472](https://github.com/google-deepmind/mujoco/issues/3472) (finding 4) is addressed, an MJCF joint equality with `active="false"` will read back as *active* through MuJoCo's importer.

That is a deliberate trade. The alternative preserves MuJoCo's round-trip by writing an assertion into the USD that is wrong on its face — a disabled joint — which every other consumer then honours. Authoring the asset correctly and letting the decoder catch up seemed the better order.

## Test plan

```
uv run --frozen python -m unittest discover -s ./tests    # 183 tests, OK
uv run --frozen poe lint                                  # black, ruff, license, uv lock all pass
```

`test_joint_equality_joint_enabled` previously asserted the old behaviour, so it codified the bug. It now asserts that an inactive joint equality leaves `physics:jointEnabled` unauthored while `newton:mimicEnabled` is false. Reverting `equality.py` alone fails it:

```
AssertionError: True is not false : physics:jointEnabled should not be authored from an inactive joint equality
```

`test_weld_equality_joint_enabled` and `test_connect_equality_enabled` are untouched and still assert `jointEnabled == false`, covering the branches where that authoring is correct.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).
