### PR TITLE
Limit usd-exchange below version 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "mujoco>=3.11.0,<3.12",
-    "usd-exchange>=2.2.2", # locked to USD 25.05
+    "usd-exchange>=2.2.2,<3", # locked to USD 25.05
     "newton-usd-schemas>=0.4.0",
     "numpy-stl>=3.2",
     "tinyobjloader>=2.0.0rc13",
@@ -31,7 +31,7 @@ dev = [
     "unittest-xml-reporting>=3.2.0",
     "pyyaml>=6.0",
     "requests>=2.32.3",
-    "usd-exchange[test]",
+    "usd-exchange[test]<3",
 ]
 
 [tool.hatch.version]

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ requires-dist = [
     { name = "newton-usd-schemas", specifier = ">=0.4.0" },
     { name = "numpy-stl", specifier = ">=3.2" },
     { name = "tinyobjloader", specifier = ">=2.0.0rc13" },
-    { name = "usd-exchange", specifier = ">=2.2.2" },
+    { name = "usd-exchange", specifier = ">=2.2.2,<3" },
 ]
 
 [package.metadata.requires-dev]
@@ -360,7 +360,7 @@ dev = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", specifier = ">=0.11" },
     { name = "unittest-xml-reporting", specifier = ">=3.2.0" },
-    { name = "usd-exchange", extras = ["test"] },
+    { name = "usd-exchange", extras = ["test"], specifier = "<3" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Keep the converter’s OpenUSD dependency on `usd-exchange` 2.x.

The converter targets OpenUSD 25.05. Therefore, a major dependency upgrade needs explicit compatibility tests.

The `<3` bound now covers normal installs and the development test dependency. `uv.lock` keeps the existing 2.2.2 selection.

Validation:

- `uv lock --check`
- `git diff --check`

I did not run runtime tests because this patch changes dependency metadata only.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/newton-physics/mujoco-usd-converter/blob/HEAD/CONTRIBUTING.md).